### PR TITLE
Fix Windows SQLite path parsing in UI server and import

### DIFF
--- a/crates/lunaroute-server/src/main.rs
+++ b/crates/lunaroute-server/src/main.rs
@@ -1250,10 +1250,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Start the UI server
 async fn start_ui_server(config: lunaroute_ui::UiConfig, db_path: String) -> anyhow::Result<()> {
-    // Connect to SQLite database
+    // Connect to SQLite database using SqliteConnectOptions to handle Windows paths correctly
+    // (URL-based connection like "sqlite://C:\..." breaks on Windows due to backslash parsing)
     let pool = sqlx::sqlite::SqlitePoolOptions::new()
         .max_connections(5)
-        .connect(&format!("sqlite://{}", db_path))
+        .connect_with(
+            sqlx::sqlite::SqliteConnectOptions::new()
+                .filename(&db_path)
+                .create_if_missing(true),
+        )
         .await?;
 
     let pool = std::sync::Arc::new(pool);

--- a/crates/lunaroute-session/src/import.rs
+++ b/crates/lunaroute-session/src/import.rs
@@ -172,9 +172,17 @@ async fn read_session_events(path: &Path) -> Result<Vec<SessionEvent>> {
 /// Check if a session exists in the database
 #[cfg(feature = "sqlite-writer")]
 async fn session_exists(db_path: &Path, session_id: &str) -> Result<bool> {
-    use sqlx::SqlitePool;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
-    let pool = SqlitePool::connect(&format!("sqlite://{}", db_path.display()))
+    // Use SqliteConnectOptions to handle Windows paths correctly
+    // (URL-based connection like "sqlite://C:\..." breaks on Windows due to backslash parsing)
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(
+            SqliteConnectOptions::new()
+                .filename(db_path)
+                .create_if_missing(false),
+        )
         .await
         .context("Failed to connect to database")?;
 


### PR DESCRIPTION
Use SqliteConnectOptions::new().filename() instead of URL-based connection strings. Windows paths like C:\Users\... contain backslashes that are misinterpreted by the SQLite URL parser, causing errors like: "unknown query parameter \C:\Users\..."

This matches the pattern already used in sqlite_writer.rs which works correctly on all platforms.

🤖 Generated with Claude Code for my sins.