### PR TITLE
feat: cross-dialect LUNAROUTE marker routing (Anthropic→OpenAI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ data/
 # Temporary files
 tmp/
 temp/
+
+# private configs
+examples/configs/private/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.12"
 edition = "2024"
 authors = ["LunaRoute Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -609,23 +609,19 @@ pub fn to_normalized(req: AnthropicMessagesRequest) -> IngressResult<NormalizedR
 /// Ensure a tool ID is valid for the Anthropic API (`^[a-zA-Z0-9_-]+$`).
 /// Converts OpenAI-format IDs (e.g. `call_xxx`) to Anthropic-format (`toolu_call_xxx`)
 /// and strips any characters outside the allowed set.
+/// Avoids double-prefixing IDs that already start with `toolu_`.
 fn to_anthropic_tool_id(id: &str) -> String {
-    // Already valid Anthropic ID
-    if id.starts_with("toolu_")
-        && !id.is_empty()
-        && id
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-    {
-        return id.to_string();
-    }
-    // Sanitize: keep only valid chars
+    // Sanitize first: keep only valid chars
     let sanitized: String = id
         .chars()
         .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
         .collect();
     if sanitized.is_empty() {
-        format!("toolu_{}", uuid::Uuid::new_v4().simple())
+        return format!("toolu_{}", uuid::Uuid::new_v4().simple());
+    }
+    // If sanitized ID already has toolu_ prefix, keep it as-is
+    if sanitized.starts_with("toolu_") {
+        sanitized
     } else {
         format!("toolu_{}", sanitized)
     }
@@ -837,12 +833,19 @@ fn stream_event_to_anthropic_events(
                 *active_block = Some(ActiveBlock::Tool(tool_call_index));
             }
 
-            // Send partial JSON if available
+            // Send partial JSON only if the matching tool block is active
             if let Some(func) = function.and_then(|f| f.arguments) {
-                events.push(AnthropicStreamEvent::ContentBlockDelta {
-                    index: tool_call_index,
-                    delta: AnthropicContentDelta::InputJsonDelta { partial_json: func },
-                });
+                if *active_block == Some(ActiveBlock::Tool(tool_call_index)) {
+                    events.push(AnthropicStreamEvent::ContentBlockDelta {
+                        index: tool_call_index,
+                        delta: AnthropicContentDelta::InputJsonDelta { partial_json: func },
+                    });
+                } else {
+                    tracing::debug!(
+                        "Dropping tool argument delta for block {} — no matching active tool block",
+                        tool_call_index
+                    );
+                }
             }
 
             events
@@ -3202,6 +3205,18 @@ mod tests {
         assert_eq!(
             to_anthropic_tool_id("chatcmpl-abc123"),
             "toolu_chatcmpl-abc123"
+        );
+
+        // toolu_ prefix with invalid chars — sanitize but don't double-prefix
+        assert_eq!(
+            to_anthropic_tool_id("toolu_functions.Bash:0"),
+            "toolu_functionsBash0"
+        );
+
+        // Already has toolu_ prefix from upstream — don't double-prefix
+        assert_eq!(
+            to_anthropic_tool_id("toolu_functionsRead0"),
+            "toolu_functionsRead0"
         );
     }
 

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -594,6 +594,31 @@ pub fn to_normalized(req: AnthropicMessagesRequest) -> IngressResult<NormalizedR
     })
 }
 
+/// Ensure a tool ID is valid for the Anthropic API (`^[a-zA-Z0-9_-]+$`).
+/// Converts OpenAI-format IDs (e.g. `call_xxx`) to Anthropic-format (`toolu_call_xxx`)
+/// and strips any characters outside the allowed set.
+fn to_anthropic_tool_id(id: &str) -> String {
+    // Already valid Anthropic ID
+    if id.starts_with("toolu_")
+        && !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return id.to_string();
+    }
+    // Sanitize: keep only valid chars
+    let sanitized: String = id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .collect();
+    if sanitized.is_empty() {
+        format!("toolu_{}", uuid::Uuid::new_v4().simple())
+    } else {
+        format!("toolu_{}", sanitized)
+    }
+}
+
 /// Convert normalized response to Anthropic response
 pub fn from_normalized(resp: NormalizedResponse) -> AnthropicResponse {
     let content: Vec<AnthropicContent> = resp
@@ -647,7 +672,7 @@ pub fn from_normalized(resp: NormalizedResponse) -> AnthropicResponse {
                 };
 
                 content_blocks.push(AnthropicContent::ToolUse {
-                    id: tool_call.id.clone(),
+                    id: to_anthropic_tool_id(&tool_call.id),
                     name: tool_call.function.name.clone(),
                     input,
                 });
@@ -764,7 +789,7 @@ fn stream_event_to_anthropic_events(
                 events.push(AnthropicStreamEvent::ContentBlockStart {
                     index: tool_call_index,
                     content_block: AnthropicContentBlockStart::ToolUse {
-                        id: tool_id,
+                        id: to_anthropic_tool_id(&tool_id),
                         name: func,
                     },
                 });
@@ -2972,7 +2997,7 @@ mod tests {
         assert!(tool_use.is_some(), "Expected tool_use block in response");
 
         if let Some(AnthropicContent::ToolUse { id, name, input }) = tool_use {
-            assert_eq!(id, "call_abc123");
+            assert_eq!(id, "toolu_call_abc123");
             assert_eq!(name, "get_weather");
             assert_eq!(input["location"], "San Francisco");
         }
@@ -3115,5 +3140,28 @@ mod tests {
             }
             _ => panic!("Expected Text content"),
         }
+    }
+
+    #[test]
+    fn test_to_anthropic_tool_id() {
+        // Already valid Anthropic ID — kept as-is
+        assert_eq!(to_anthropic_tool_id("toolu_abc123"), "toolu_abc123");
+
+        // OpenAI call_ format — gets toolu_ prefix
+        assert_eq!(to_anthropic_tool_id("call_abc123"), "toolu_call_abc123");
+
+        // ID with invalid characters — stripped and prefixed
+        assert_eq!(to_anthropic_tool_id("call.abc:123"), "toolu_callabc123");
+
+        // Empty ID — generates UUID-based ID
+        let id = to_anthropic_tool_id("");
+        assert!(id.starts_with("toolu_"));
+        assert!(id.len() > 6);
+
+        // Hyphenated ID — hyphens are valid
+        assert_eq!(
+            to_anthropic_tool_id("chatcmpl-abc123"),
+            "toolu_chatcmpl-abc123"
+        );
     }
 }

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -60,10 +60,36 @@ pub enum AnthropicSystem {
 }
 
 /// Anthropic system content block
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AnthropicSystemBlock {
-    Text { text: String },
+    Text {
+        text: String,
+    },
+    #[serde(skip)]
+    Unknown(serde_json::Value),
+}
+
+impl<'de> serde::Deserialize<'de> for AnthropicSystemBlock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let block_type = value.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        match block_type {
+            "text" => {
+                let text = value
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Ok(Self::Text { text })
+            }
+            _ => Ok(Self::Unknown(value)),
+        }
+    }
 }
 
 /// Anthropic messages request
@@ -106,7 +132,10 @@ pub enum AnthropicMessageContent {
 }
 
 /// Anthropic content block (for requests)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Uses custom Deserialize to gracefully handle unknown block types (e.g. `thinking`,
+/// `redacted_thinking`, `image`) that Claude Code may send but we don't need to normalize.
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AnthropicContentBlock {
     Text {
@@ -123,6 +152,77 @@ pub enum AnthropicContentBlock {
         #[serde(default)]
         is_error: Option<bool>,
     },
+    /// Catch-all for unknown block types (thinking, image, etc.) — skipped during normalization
+    #[serde(skip)]
+    Unknown(serde_json::Value),
+}
+
+impl<'de> serde::Deserialize<'de> for AnthropicContentBlock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let block_type = value.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        match block_type {
+            "text" => {
+                let text = value
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Ok(Self::Text { text })
+            }
+            "tool_use" => {
+                let id = value
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let name = value
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let input = value
+                    .get("input")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Object(Default::default()));
+                Ok(Self::ToolUse { id, name, input })
+            }
+            "tool_result" => {
+                let tool_use_id = value
+                    .get("tool_use_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                // Content can be either a string or an array of content blocks
+                let content = match value.get("content") {
+                    Some(serde_json::Value::String(s)) => s.clone(),
+                    Some(serde_json::Value::Array(arr)) => arr
+                        .iter()
+                        .filter_map(|b| {
+                            if b.get("type").and_then(|t| t.as_str()) == Some("text") {
+                                b.get("text").and_then(|t| t.as_str()).map(String::from)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                    _ => String::new(),
+                };
+                let is_error = value.get("is_error").and_then(|v| v.as_bool());
+                Ok(Self::ToolResult {
+                    tool_use_id,
+                    content,
+                    is_error,
+                })
+            }
+            _ => Ok(Self::Unknown(value)),
+        }
+    }
 }
 
 /// Anthropic response
@@ -413,6 +513,9 @@ pub fn to_normalized(req: AnthropicMessagesRequest) -> IngressResult<NormalizedR
                                     tool_name: None, // Will be filled in by SessionRecorder
                                 });
                             }
+                            AnthropicContentBlock::Unknown(_) => {
+                                // Skip unknown block types (thinking, image, etc.)
+                            }
                         }
                     }
 
@@ -462,11 +565,12 @@ pub fn to_normalized(req: AnthropicMessagesRequest) -> IngressResult<NormalizedR
     let system = req.system.map(|sys| match sys {
         AnthropicSystem::Text(text) => text,
         AnthropicSystem::Blocks(blocks) => {
-            // Concatenate all text blocks
+            // Concatenate all text blocks, skip unknown types
             blocks
                 .into_iter()
-                .map(|block| match block {
-                    AnthropicSystemBlock::Text { text } => text,
+                .filter_map(|block| match block {
+                    AnthropicSystemBlock::Text { text } => Some(text),
+                    AnthropicSystemBlock::Unknown(_) => None,
                 })
                 .collect::<Vec<_>>()
                 .join("\n")
@@ -2391,6 +2495,7 @@ mod tests {
                 assert_eq!(blocks.len(), 1);
                 match &blocks[0] {
                     AnthropicSystemBlock::Text { text } => assert_eq!(text, "You are helpful"),
+                    AnthropicSystemBlock::Unknown(_) => panic!("Expected Text variant"),
                 }
             }
             _ => panic!("Expected Blocks variant"),
@@ -2936,5 +3041,79 @@ mod tests {
         let typed_req: AnthropicMessagesRequest = serde_json::from_value(req).unwrap();
         let normalized = to_normalized(typed_req).unwrap();
         assert_eq!(normalized.model, "@cf/moonshotai/kimi-k2.5");
+    }
+
+    #[test]
+    fn test_unknown_content_blocks_are_skipped_during_normalization() {
+        // Claude Code sends thinking/redacted_thinking blocks that we don't normalize
+        let raw_json = serde_json::json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hello"}]
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "Let me think about this..."},
+                        {"type": "redacted_thinking", "data": "abc123"},
+                        {"type": "text", "text": "Hi there!"}
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": "Follow up question"
+                }
+            ],
+            "max_tokens": 1024,
+            "stream": false
+        });
+
+        let typed_req: AnthropicMessagesRequest = serde_json::from_value(raw_json).unwrap();
+        assert_eq!(typed_req.messages.len(), 3);
+
+        let normalized = to_normalized(typed_req).unwrap();
+        assert_eq!(normalized.messages.len(), 3);
+        // Assistant message should only contain the text block, not thinking blocks
+        assert_eq!(
+            normalized.messages[1].content,
+            MessageContent::Text("Hi there!".to_string())
+        );
+    }
+
+    #[test]
+    fn test_tool_result_with_array_content() {
+        // Anthropic API allows tool_result content to be an array of blocks
+        let raw_json = serde_json::json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_123",
+                            "content": [
+                                {"type": "text", "text": "Result line 1"},
+                                {"type": "text", "text": "Result line 2"}
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "max_tokens": 1024
+        });
+
+        let typed_req: AnthropicMessagesRequest = serde_json::from_value(raw_json).unwrap();
+        let normalized = to_normalized(typed_req).unwrap();
+        // Array content should be joined with newlines
+        match &normalized.messages[0].content {
+            MessageContent::Text(text) => {
+                assert!(text.contains("Result line 1"));
+                assert!(text.contains("Result line 2"));
+            }
+            _ => panic!("Expected Text content"),
+        }
     }
 }

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -2769,4 +2769,78 @@ mod tests {
         assert!(content_block_started);
         assert!(anthropic_events.len() >= 2);
     }
+
+    #[test]
+    fn test_cross_dialect_tool_use_roundtrip() {
+        let raw_json = serde_json::json!({
+            "model": "@cf/moonshotai/kimi-k2.5",
+            "messages": [
+                {"role": "user", "content": "What's the weather?"}
+            ],
+            "max_tokens": 1024,
+            "stream": false,
+            "tools": [{
+                "name": "get_weather",
+                "description": "Get weather for a location",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"}
+                    },
+                    "required": ["location"]
+                }
+            }]
+        });
+
+        let typed_req: AnthropicMessagesRequest = serde_json::from_value(raw_json).unwrap();
+        let normalized = to_normalized(typed_req).unwrap();
+
+        assert_eq!(normalized.tools.len(), 1);
+        assert_eq!(normalized.tools[0].function.name, "get_weather");
+
+        let normalized_resp = NormalizedResponse {
+            id: "chatcmpl-test".to_string(),
+            model: "@cf/moonshotai/kimi-k2.5".to_string(),
+            choices: vec![Choice {
+                index: 0,
+                message: Message {
+                    role: Role::Assistant,
+                    content: MessageContent::Text(String::new()),
+                    name: None,
+                    tool_calls: vec![ToolCall {
+                        id: "call_abc123".to_string(),
+                        tool_type: "function".to_string(),
+                        function: FunctionCall {
+                            name: "get_weather".to_string(),
+                            arguments: r#"{"location":"San Francisco"}"#.to_string(),
+                        },
+                    }],
+                    tool_call_id: None,
+                },
+                finish_reason: Some(FinishReason::ToolCalls),
+            }],
+            usage: Usage {
+                prompt_tokens: 20,
+                completion_tokens: 10,
+                total_tokens: 30,
+            },
+            created: 1234567890,
+            metadata: std::collections::HashMap::new(),
+        };
+
+        let anthropic_resp = from_normalized(normalized_resp);
+        assert_eq!(anthropic_resp.stop_reason, Some("tool_use".to_string()));
+
+        let tool_use = anthropic_resp
+            .content
+            .iter()
+            .find(|c| matches!(c, AnthropicContent::ToolUse { .. }));
+        assert!(tool_use.is_some(), "Expected tool_use block in response");
+
+        if let Some(AnthropicContent::ToolUse { id, name, input }) = tool_use {
+            assert_eq!(id, "call_abc123");
+            assert_eq!(name, "get_weather");
+            assert_eq!(input["location"], "San Francisco");
+        }
+    }
 }

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -83,7 +83,7 @@ impl<'de> serde::Deserialize<'de> for AnthropicSystemBlock {
                 let text = value
                     .get("text")
                     .and_then(|t| t.as_str())
-                    .unwrap_or("")
+                    .ok_or_else(|| serde::de::Error::missing_field("text"))?
                     .to_string();
                 Ok(Self::Text { text })
             }
@@ -170,7 +170,7 @@ impl<'de> serde::Deserialize<'de> for AnthropicContentBlock {
                 let text = value
                     .get("text")
                     .and_then(|t| t.as_str())
-                    .unwrap_or("")
+                    .ok_or_else(|| serde::de::Error::missing_field("text"))?
                     .to_string();
                 Ok(Self::Text { text })
             }
@@ -178,12 +178,12 @@ impl<'de> serde::Deserialize<'de> for AnthropicContentBlock {
                 let id = value
                     .get("id")
                     .and_then(|v| v.as_str())
-                    .unwrap_or("")
+                    .ok_or_else(|| serde::de::Error::missing_field("id"))?
                     .to_string();
                 let name = value
                     .get("name")
                     .and_then(|v| v.as_str())
-                    .unwrap_or("")
+                    .ok_or_else(|| serde::de::Error::missing_field("name"))?
                     .to_string();
                 let input = value
                     .get("input")
@@ -195,7 +195,7 @@ impl<'de> serde::Deserialize<'de> for AnthropicContentBlock {
                 let tool_use_id = value
                     .get("tool_use_id")
                     .and_then(|v| v.as_str())
-                    .unwrap_or("")
+                    .ok_or_else(|| serde::de::Error::missing_field("tool_use_id"))?
                     .to_string();
                 // Content can be either a string or an array of content blocks
                 let content = match value.get("content") {

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -742,33 +742,57 @@ pub fn from_normalized(resp: NormalizedResponse) -> AnthropicResponse {
     }
 }
 
-/// Tracks the currently active content block in a streaming Anthropic response.
-/// Ensures proper Start→Delta→Stop sequencing and correct transitions between block types.
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum ActiveBlock {
-    Text(u32),
-    Tool(u32),
+/// Tracks streaming content block state with unique Anthropic index allocation.
+/// OpenAI tool_call_index can collide with text delta indices (both start at 0),
+/// so we allocate monotonically increasing Anthropic indices to avoid duplicates.
+#[derive(Debug, Clone, Default)]
+struct StreamBlockState {
+    /// The Anthropic block index of the currently active block, if any
+    active_index: Option<u32>,
+    /// Whether the active block is a tool block
+    active_is_tool: bool,
+    /// The OpenAI tool_call_index of the active tool block (for matching deltas)
+    active_tool_call_index: Option<u32>,
+    /// Next Anthropic content block index to allocate
+    next_index: u32,
+    /// Maps OpenAI tool_call_index → allocated Anthropic block index
+    tool_index_map: std::collections::HashMap<u32, u32>,
+}
+
+impl StreamBlockState {
+    fn close_active(&mut self, events: &mut Vec<AnthropicStreamEvent>) {
+        if let Some(idx) = self.active_index.take() {
+            events.push(AnthropicStreamEvent::ContentBlockStop { index: idx });
+            self.active_is_tool = false;
+            self.active_tool_call_index = None;
+        }
+    }
+
+    fn alloc_index(&mut self) -> u32 {
+        let idx = self.next_index;
+        self.next_index += 1;
+        idx
+    }
 }
 
 /// Convert normalized stream event to Anthropic SSE events
 /// Returns a vector because some normalized events map to multiple Anthropic events
 ///
 /// State Management:
-/// - `active_block` tracks both the type and index of the currently open ContentBlock
-/// - `None` means no block is open; `Some(ActiveBlock::*)` means that block needs a Stop event
-/// - On type/index changes, the previous block is closed before the new one opens
+/// - `state` tracks the active block, allocates unique Anthropic indices, and maps
+///   OpenAI tool_call_index values to allocated indices to prevent collisions
 /// - State is maintained per-stream via scan() combinator (sequential, no concurrency)
 fn stream_event_to_anthropic_events(
     event: NormalizedStreamEvent,
     stream_id: &str,
     model: &str,
-    active_block: &mut Option<ActiveBlock>,
+    state: &mut StreamBlockState,
 ) -> Vec<AnthropicStreamEvent> {
     use tracing::debug;
     match event {
         NormalizedStreamEvent::Start { .. } => {
             // Reset state for new stream
-            *active_block = None;
+            *state = StreamBlockState::default();
             debug!("Anthropic stream started: stream_id={}", stream_id);
 
             // Anthropic starts with message_start event
@@ -787,36 +811,31 @@ fn stream_event_to_anthropic_events(
                 },
             }]
         }
-        NormalizedStreamEvent::Delta { index, delta } => {
+        NormalizedStreamEvent::Delta { index: _, delta } => {
             let mut events = Vec::new();
-            let want = ActiveBlock::Text(index);
 
-            // If a different block is active, close it first
-            if let Some(prev) = *active_block
-                && prev != want
-            {
-                let prev_idx = match prev {
-                    ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
-                };
-                events.push(AnthropicStreamEvent::ContentBlockStop { index: prev_idx });
-                *active_block = None;
+            // If a non-text block is active, close it first
+            if state.active_index.is_some() && state.active_is_tool {
+                state.close_active(&mut events);
             }
 
             // Open text block if not already active
-            if active_block.is_none() {
+            if state.active_index.is_none() {
+                let idx = state.alloc_index();
                 events.push(AnthropicStreamEvent::ContentBlockStart {
-                    index,
+                    index: idx,
                     content_block: AnthropicContentBlockStart::Text {
                         text: String::new(),
                     },
                 });
-                *active_block = Some(want);
+                state.active_index = Some(idx);
+                state.active_is_tool = false;
             }
 
             // Send the text delta
             if let Some(content) = delta.content {
                 events.push(AnthropicStreamEvent::ContentBlockDelta {
-                    index,
+                    index: state.active_index.unwrap(),
                     delta: AnthropicContentDelta::TextDelta { text: content },
                 });
             }
@@ -835,33 +854,35 @@ fn stream_event_to_anthropic_events(
             if let (Some(tool_id), Some(func)) =
                 (id, function.as_ref().and_then(|f| f.name.clone()))
             {
-                let want = ActiveBlock::Tool(tool_call_index);
+                let already_active =
+                    state.active_is_tool && state.active_tool_call_index == Some(tool_call_index);
 
-                if *active_block != Some(want) {
-                    // Close previous block if one is active (any type/index transition)
-                    if let Some(prev) = *active_block {
-                        let prev_idx = match prev {
-                            ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
-                        };
-                        events.push(AnthropicStreamEvent::ContentBlockStop { index: prev_idx });
-                    }
+                if !already_active {
+                    // Close previous block if one is active
+                    state.close_active(&mut events);
+
+                    // Allocate a unique Anthropic index for this tool block
+                    let idx = state.alloc_index();
+                    state.tool_index_map.insert(tool_call_index, idx);
 
                     events.push(AnthropicStreamEvent::ContentBlockStart {
-                        index: tool_call_index,
+                        index: idx,
                         content_block: AnthropicContentBlockStart::ToolUse {
                             id: to_anthropic_tool_id(&tool_id),
                             name: func,
                         },
                     });
-                    *active_block = Some(want);
+                    state.active_index = Some(idx);
+                    state.active_is_tool = true;
+                    state.active_tool_call_index = Some(tool_call_index);
                 }
             }
 
             // Send partial JSON only if the matching tool block is active
             if let Some(func) = function.and_then(|f| f.arguments) {
-                if *active_block == Some(ActiveBlock::Tool(tool_call_index)) {
+                if state.active_is_tool && state.active_tool_call_index == Some(tool_call_index) {
                     events.push(AnthropicStreamEvent::ContentBlockDelta {
-                        index: tool_call_index,
+                        index: state.active_index.unwrap(),
                         delta: AnthropicContentDelta::InputJsonDelta { partial_json: func },
                     });
                 } else {
@@ -882,12 +903,9 @@ fn stream_event_to_anthropic_events(
             let mut events = Vec::new();
 
             // Close whichever content block is currently active (text or tool)
-            if let Some(prev) = active_block.take() {
-                let idx = match prev {
-                    ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
-                };
-                events.push(AnthropicStreamEvent::ContentBlockStop { index: idx });
-                debug!("Anthropic content block {} closed", idx);
+            if state.active_index.is_some() {
+                state.close_active(&mut events);
+                debug!("Anthropic content block closed");
             } else {
                 debug!("Anthropic stream ended without content block");
             }
@@ -964,7 +982,7 @@ pub async fn messages(
         // Convert normalized events to Anthropic SSE format
         // Use scan to maintain state across stream events
         let sse_stream = stream
-            .scan(None::<ActiveBlock>, move |active_block, result| {
+            .scan(StreamBlockState::default(), move |block_state, result| {
                 let stream_id = Arc::clone(&stream_id);
                 let model = Arc::clone(&model);
 
@@ -974,7 +992,7 @@ pub async fn messages(
                             event,
                             stream_id.as_str(),
                             model.as_str(),
-                            active_block,
+                            block_state,
                         );
 
                         anthropic_events
@@ -992,15 +1010,11 @@ pub async fn messages(
                         let mut error_events = Vec::new();
 
                         // Close any active content block before the error
-                        if let Some(prev) = active_block.take() {
-                            let idx = match prev {
-                                ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
-                            };
-                            if let Ok(evt) = Event::default()
+                        if let Some(idx) = block_state.active_index.take()
+                            && let Ok(evt) = Event::default()
                                 .json_data(AnthropicStreamEvent::ContentBlockStop { index: idx })
-                            {
-                                error_events.push(Ok(evt));
-                            }
+                        {
+                            error_events.push(Ok(evt));
                         }
 
                         // Send error event
@@ -1503,7 +1517,7 @@ pub async fn messages_passthrough(
             let full_stream = start_event.chain(event_stream);
 
             let sse_stream = full_stream
-                .scan(None::<ActiveBlock>, move |active_block, result| {
+                .scan(StreamBlockState::default(), move |block_state, result| {
                     let stream_id = Arc::clone(&stream_id);
                     let model = Arc::clone(&model_arc);
                     let sse_events: Vec<Result<Event, IngressError>> = match result {
@@ -1512,7 +1526,7 @@ pub async fn messages_passthrough(
                                 event,
                                 stream_id.as_str(),
                                 model.as_str(),
-                                active_block,
+                                block_state,
                             );
                             events
                                 .into_iter()
@@ -1530,15 +1544,12 @@ pub async fn messages_passthrough(
                             let mut error_events = Vec::new();
 
                             // Close any active content block before the error
-                            if let Some(prev) = active_block.take() {
-                                let idx = match prev {
-                                    ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
-                                };
-                                if let Ok(evt) = Event::default().json_data(
+                            if let Some(idx) = block_state.active_index.take()
+                                && let Ok(evt) = Event::default().json_data(
                                     AnthropicStreamEvent::ContentBlockStop { index: idx },
-                                ) {
-                                    error_events.push(Ok(evt));
-                                }
+                                )
+                            {
+                                error_events.push(Ok(evt));
                             }
 
                             // Send the error event
@@ -3030,7 +3041,7 @@ mod tests {
     fn test_cross_dialect_stream_event_conversion() {
         use lunaroute_core::normalized::Delta;
 
-        let mut active_block: Option<ActiveBlock> = None;
+        let mut block_state = StreamBlockState::default();
 
         let event = NormalizedStreamEvent::Delta {
             index: 0,
@@ -3044,10 +3055,11 @@ mod tests {
             event,
             "msg_test123",
             "@cf/moonshotai/kimi-k2.5",
-            &mut active_block,
+            &mut block_state,
         );
 
-        assert_eq!(active_block, Some(ActiveBlock::Text(0)));
+        assert_eq!(block_state.active_index, Some(0));
+        assert!(!block_state.active_is_tool);
         assert!(anthropic_events.len() >= 2);
     }
 
@@ -3129,7 +3141,7 @@ mod tests {
     fn test_cross_dialect_stream_error_produces_sse_error_event() {
         use lunaroute_core::normalized::Delta;
 
-        let mut active_block: Option<ActiveBlock> = None;
+        let mut block_state = StreamBlockState::default();
 
         // First send a valid delta to start content block
         let event = NormalizedStreamEvent::Delta {
@@ -3140,8 +3152,9 @@ mod tests {
             },
         };
         let events =
-            stream_event_to_anthropic_events(event, "msg_test", "test-model", &mut active_block);
-        assert_eq!(active_block, Some(ActiveBlock::Text(0)));
+            stream_event_to_anthropic_events(event, "msg_test", "test-model", &mut block_state);
+        assert_eq!(block_state.active_index, Some(0));
+        assert!(!block_state.active_is_tool);
         assert!(!events.is_empty());
 
         // Verify error SSE event can be constructed (matching the cross-dialect error path)
@@ -3306,7 +3319,7 @@ mod tests {
     fn test_streaming_tool_call_block_lifecycle() {
         use lunaroute_core::normalized::{FinishReason, FunctionCallDelta};
 
-        let mut active_block: Option<ActiveBlock> = None;
+        let mut block_state = StreamBlockState::default();
 
         // 1. Start event resets state
         let events = stream_event_to_anthropic_events(
@@ -3316,9 +3329,9 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block,
+            &mut block_state,
         );
-        assert_eq!(active_block, None);
+        assert_eq!(block_state.active_index, None);
         assert_eq!(events.len(), 1); // message_start
 
         // 2. Tool call start — should open a block
@@ -3334,9 +3347,10 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block,
+            &mut block_state,
         );
-        assert_eq!(active_block, Some(ActiveBlock::Tool(0)));
+        assert!(block_state.active_is_tool);
+        assert!(block_state.active_index.is_some());
         // Should have ContentBlockStart (no prior block to close)
         assert!(
             events
@@ -3357,7 +3371,7 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block,
+            &mut block_state,
         );
         assert_eq!(events.len(), 1); // Just the delta
         assert!(matches!(
@@ -3372,9 +3386,9 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block,
+            &mut block_state,
         );
-        assert_eq!(active_block, None);
+        assert_eq!(block_state.active_index, None);
         // Should have ContentBlockStop at index 0, MessageDelta, MessageStop
         assert!(
             events
@@ -3392,7 +3406,7 @@ mod tests {
     fn test_streaming_text_to_tool_transition() {
         use lunaroute_core::normalized::{Delta, FinishReason, FunctionCallDelta};
 
-        let mut active_block: Option<ActiveBlock> = None;
+        let mut block_state = StreamBlockState::default();
 
         // Start
         let _ = stream_event_to_anthropic_events(
@@ -3402,7 +3416,7 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block,
+            &mut block_state,
         );
 
         // Text delta — opens block 0
@@ -3416,9 +3430,10 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block,
+            &mut block_state,
         );
-        assert_eq!(active_block, Some(ActiveBlock::Text(0)));
+        assert_eq!(block_state.active_index, Some(0));
+        assert!(!block_state.active_is_tool);
 
         // Tool call starts — should close text block 0, open tool block 1
         let events = stream_event_to_anthropic_events(
@@ -3433,9 +3448,10 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block,
+            &mut block_state,
         );
-        assert_eq!(active_block, Some(ActiveBlock::Tool(1)));
+        assert!(block_state.active_is_tool);
+        assert!(block_state.active_index.is_some());
         // Should have ContentBlockStop for index 0, then ContentBlockStart for index 1
         assert!(
             events
@@ -3448,20 +3464,104 @@ mod tests {
                 .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStart { index: 1, .. }))
         );
 
-        // End — should close tool block 1
+        // End — should close tool block
+        let tool_idx = block_state.active_index.unwrap();
         let events = stream_event_to_anthropic_events(
             NormalizedStreamEvent::End {
                 finish_reason: FinishReason::ToolCalls,
             },
             "msg_test",
             "test-model",
-            &mut active_block,
+            &mut block_state,
         );
-        assert_eq!(active_block, None);
+        assert_eq!(block_state.active_index, None);
+        assert!(events.iter().any(
+            |e| matches!(e, AnthropicStreamEvent::ContentBlockStop { index } if *index == tool_idx)
+        ));
+    }
+
+    #[test]
+    fn test_streaming_text_then_tool_at_same_openai_index() {
+        // OpenAI sends text deltas at index 0, then tool_call at tool_call_index 0.
+        // Anthropic indices must NOT collide — tool should get a unique index.
+        use lunaroute_core::normalized::{Delta, FinishReason, FunctionCallDelta};
+
+        let mut block_state = StreamBlockState::default();
+
+        // Start
+        let _ = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::Start {
+                id: "msg_test".to_string(),
+                model: "test-model".to_string(),
+            },
+            "msg_test",
+            "test-model",
+            &mut block_state,
+        );
+
+        // Text delta — gets Anthropic index 0
+        let events = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::Delta {
+                index: 0,
+                delta: Delta {
+                    role: None,
+                    content: Some("Sure, let me check.".to_string()),
+                },
+            },
+            "msg_test",
+            "test-model",
+            &mut block_state,
+        );
+        let text_idx = block_state.active_index.unwrap();
+        assert_eq!(text_idx, 0);
         assert!(
             events
                 .iter()
-                .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStop { index: 1 }))
+                .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStart { index: 0, .. }))
         );
+
+        // Tool call at OpenAI tool_call_index 0 — must get Anthropic index 1, NOT 0
+        let events = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::ToolCallDelta {
+                index: 0,
+                tool_call_index: 0, // Same as text index!
+                id: Some("call_abc".to_string()),
+                function: Some(FunctionCallDelta {
+                    name: Some("Bash".to_string()),
+                    arguments: None,
+                }),
+            },
+            "msg_test",
+            "test-model",
+            &mut block_state,
+        );
+        let tool_idx = block_state.active_index.unwrap();
+        // Tool must have a DIFFERENT Anthropic index than text
+        assert_ne!(tool_idx, text_idx);
+        assert!(block_state.active_is_tool);
+        // Should close text block at index 0
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStop { index: 0 }))
+        );
+        // Should open tool block at a new index (1)
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStart { index, .. } if *index == tool_idx)));
+
+        // End
+        let events = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::End {
+                finish_reason: FinishReason::ToolCalls,
+            },
+            "msg_test",
+            "test-model",
+            &mut block_state,
+        );
+        assert_eq!(block_state.active_index, None);
+        assert!(events.iter().any(
+            |e| matches!(e, AnthropicStreamEvent::ContentBlockStop { index } if *index == tool_idx)
+        ));
     }
 }

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -1251,8 +1251,56 @@ pub async fn messages_passthrough(
             })?;
 
         if is_streaming {
-            // Streaming cross-dialect handled in Task 2
-            todo!("Streaming cross-dialect not yet implemented");
+            let mut normalized = to_normalized(typed_req)?;
+            normalized.stream = true;
+
+            let event_stream = cd_connector
+                .stream(normalized)
+                .await
+                .map_err(|e| IngressError::ProviderError(e.to_string()))?;
+
+            let stream_id = Arc::new(format!("msg_{}", uuid::Uuid::new_v4().simple()));
+            let model_arc = Arc::new(model.clone());
+
+            let sse_stream = event_stream
+                .scan(false, move |content_block_started, result| {
+                    let stream_id = Arc::clone(&stream_id);
+                    let model = Arc::clone(&model_arc);
+                    let events = match result {
+                        Ok(event) => stream_event_to_anthropic_events(
+                            event,
+                            stream_id.as_str(),
+                            model.as_str(),
+                            content_block_started,
+                        ),
+                        Err(e) => {
+                            tracing::error!("Cross-dialect stream error: {}", e);
+                            vec![]
+                        }
+                    };
+                    let sse_events: Vec<Result<Event, IngressError>> = events
+                        .into_iter()
+                        .map(|evt| match Event::default().json_data(evt) {
+                            Ok(event) => Ok::<_, IngressError>(event),
+                            Err(e) => Err(IngressError::Internal(format!(
+                                "Failed to create SSE event: {}",
+                                e
+                            ))),
+                        })
+                        .collect();
+                    futures::future::ready(Some(futures::stream::iter(sse_events)))
+                })
+                .flatten();
+
+            return Ok(Sse::new(sse_stream)
+                .keep_alive(
+                    KeepAlive::new()
+                        .interval(std::time::Duration::from_secs(
+                            state.sse_keepalive_interval_secs,
+                        ))
+                        .text(""),
+                )
+                .into_response());
         } else {
             let mut normalized = to_normalized(typed_req)?;
             normalized.stream = false;
@@ -2695,5 +2743,30 @@ mod tests {
             AnthropicContent::Text { text } => assert_eq!(text, "Hello from Kimi"),
             _ => panic!("Expected text content"),
         }
+    }
+
+    #[test]
+    fn test_cross_dialect_stream_event_conversion() {
+        use lunaroute_core::normalized::Delta;
+
+        let mut content_block_started = false;
+
+        let event = NormalizedStreamEvent::Delta {
+            index: 0,
+            delta: Delta {
+                role: None,
+                content: Some("Hello from Kimi".to_string()),
+            },
+        };
+
+        let anthropic_events = stream_event_to_anthropic_events(
+            event,
+            "msg_test123",
+            "@cf/moonshotai/kimi-k2.5",
+            &mut content_block_started,
+        );
+
+        assert!(content_block_started);
+        assert!(anthropic_events.len() >= 2);
     }
 }

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -913,6 +913,10 @@ pub async fn messages_passthrough(
                                 "LUNAROUTE marker '{}' targets OpenAI provider but no OpenAI connector available",
                                 name
                             );
+                            return Err(IngressError::InvalidRequest(format!(
+                                "LUNAROUTE marker targets provider '{}' but no OpenAI connector is configured for it",
+                                name
+                            )));
                         }
                     } else if let Some(ref connector) = entry.anthropic_connector {
                         tracing::info!(
@@ -1266,28 +1270,42 @@ pub async fn messages_passthrough(
                 .scan(false, move |content_block_started, result| {
                     let stream_id = Arc::clone(&stream_id);
                     let model = Arc::clone(&model_arc);
-                    let events = match result {
-                        Ok(event) => stream_event_to_anthropic_events(
-                            event,
-                            stream_id.as_str(),
-                            model.as_str(),
-                            content_block_started,
-                        ),
+                    let sse_events: Vec<Result<Event, IngressError>> = match result {
+                        Ok(event) => {
+                            let events = stream_event_to_anthropic_events(
+                                event,
+                                stream_id.as_str(),
+                                model.as_str(),
+                                content_block_started,
+                            );
+                            events
+                                .into_iter()
+                                .map(|evt| match Event::default().json_data(evt) {
+                                    Ok(event) => Ok::<_, IngressError>(event),
+                                    Err(e) => Err(IngressError::Internal(format!(
+                                        "Failed to create SSE event: {}",
+                                        e
+                                    ))),
+                                })
+                                .collect()
+                        }
                         Err(e) => {
                             tracing::error!("Cross-dialect stream error: {}", e);
-                            vec![]
+                            let error_event = serde_json::json!({
+                                "type": "error",
+                                "error": {
+                                    "type": "api_error",
+                                    "message": e.to_string()
+                                }
+                            });
+                            match Event::default().json_data(error_event) {
+                                Ok(event) => vec![Ok(event)],
+                                Err(_) => vec![Err(IngressError::Internal(
+                                    "Failed to create error SSE event".to_string(),
+                                ))],
+                            }
                         }
                     };
-                    let sse_events: Vec<Result<Event, IngressError>> = events
-                        .into_iter()
-                        .map(|evt| match Event::default().json_data(evt) {
-                            Ok(event) => Ok::<_, IngressError>(event),
-                            Err(e) => Err(IngressError::Internal(format!(
-                                "Failed to create SSE event: {}",
-                                e
-                            ))),
-                        })
-                        .collect();
                     futures::future::ready(Some(futures::stream::iter(sse_events)))
                 })
                 .flatten();
@@ -2842,5 +2860,70 @@ mod tests {
             assert_eq!(name, "get_weather");
             assert_eq!(input["location"], "San Francisco");
         }
+    }
+
+    #[test]
+    fn test_cross_dialect_stream_error_produces_sse_error_event() {
+        use lunaroute_core::normalized::Delta;
+
+        let mut content_block_started = false;
+
+        // First send a valid delta to start content block
+        let event = NormalizedStreamEvent::Delta {
+            index: 0,
+            delta: Delta {
+                role: None,
+                content: Some("partial".to_string()),
+            },
+        };
+        let events = stream_event_to_anthropic_events(
+            event,
+            "msg_test",
+            "test-model",
+            &mut content_block_started,
+        );
+        assert!(content_block_started);
+        assert!(!events.is_empty());
+
+        // Verify error SSE event can be constructed (matching the cross-dialect error path)
+        let error_event = serde_json::json!({
+            "type": "error",
+            "error": {
+                "type": "api_error",
+                "message": "upstream provider error"
+            }
+        });
+        let sse_result = Event::default().json_data(error_event);
+        assert!(
+            sse_result.is_ok(),
+            "Error SSE event should serialize successfully"
+        );
+    }
+
+    #[test]
+    fn test_cross_dialect_model_override_applied_before_extraction() {
+        // Verify that model override applied to raw JSON is visible when extracting model
+        let mut req = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "messages": [{"role": "user", "content": "test"}],
+            "max_tokens": 1024
+        });
+
+        // Simulate model override (as done in marker match block)
+        req["model"] = serde_json::Value::String("@cf/moonshotai/kimi-k2.5".to_string());
+
+        // Simulate model extraction (as done later in handler)
+        let model = req
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        assert_eq!(model, "@cf/moonshotai/kimi-k2.5");
+
+        // Also verify normalization sees the overridden model
+        let typed_req: AnthropicMessagesRequest = serde_json::from_value(req).unwrap();
+        let normalized = to_normalized(typed_req).unwrap();
+        assert_eq!(normalized.model, "@cf/moonshotai/kimi-k2.5");
     }
 }

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -718,20 +718,21 @@ pub fn from_normalized(resp: NormalizedResponse) -> AnthropicResponse {
 /// Returns a vector because some normalized events map to multiple Anthropic events
 ///
 /// State Management:
-/// - `content_block_started` tracks whether we've sent a ContentBlockStart event
-/// - This ensures proper event sequencing: Start → Delta → Stop
+/// - `active_block_index` tracks the index of the currently open ContentBlock
+/// - `None` means no block is open; `Some(i)` means block `i` needs a Stop event
+/// - This ensures proper event sequencing: Start → Delta → Stop for both text and tool blocks
 /// - State is maintained per-stream via scan() combinator (sequential, no concurrency)
 fn stream_event_to_anthropic_events(
     event: NormalizedStreamEvent,
     stream_id: &str,
     model: &str,
-    content_block_started: &mut bool,
+    active_block_index: &mut Option<u32>,
 ) -> Vec<AnthropicStreamEvent> {
     use tracing::debug;
     match event {
         NormalizedStreamEvent::Start { .. } => {
             // Reset state for new stream
-            *content_block_started = false;
+            *active_block_index = None;
             debug!("Anthropic stream started: stream_id={}", stream_id);
 
             // Anthropic starts with message_start event
@@ -754,14 +755,14 @@ fn stream_event_to_anthropic_events(
             let mut events = Vec::new();
 
             // For first delta, send content_block_start
-            if !*content_block_started {
+            if active_block_index.is_none() {
                 events.push(AnthropicStreamEvent::ContentBlockStart {
                     index,
                     content_block: AnthropicContentBlockStart::Text {
                         text: String::new(),
                     },
                 });
-                *content_block_started = true;
+                *active_block_index = Some(index);
             }
 
             // Send the text delta
@@ -786,6 +787,11 @@ fn stream_event_to_anthropic_events(
             if let (Some(tool_id), Some(func)) =
                 (id, function.as_ref().and_then(|f| f.name.clone()))
             {
+                // Close previous block if one is active (e.g. text → tool transition)
+                if let Some(prev_idx) = *active_block_index {
+                    events.push(AnthropicStreamEvent::ContentBlockStop { index: prev_idx });
+                }
+
                 events.push(AnthropicStreamEvent::ContentBlockStart {
                     index: tool_call_index,
                     content_block: AnthropicContentBlockStart::ToolUse {
@@ -793,6 +799,7 @@ fn stream_event_to_anthropic_events(
                         name: func,
                     },
                 });
+                *active_block_index = Some(tool_call_index);
             }
 
             // Send partial JSON if available
@@ -812,11 +819,10 @@ fn stream_event_to_anthropic_events(
         NormalizedStreamEvent::End { finish_reason } => {
             let mut events = Vec::new();
 
-            // Close content block if it was started
-            if *content_block_started {
-                events.push(AnthropicStreamEvent::ContentBlockStop { index: 0 });
-                *content_block_started = false;
-                debug!("Anthropic content block closed");
+            // Close whichever content block is currently active (text or tool)
+            if let Some(idx) = active_block_index.take() {
+                events.push(AnthropicStreamEvent::ContentBlockStop { index: idx });
+                debug!("Anthropic content block {} closed", idx);
             } else {
                 debug!("Anthropic stream ended without content block");
             }
@@ -893,7 +899,7 @@ pub async fn messages(
         // Convert normalized events to Anthropic SSE format
         // Use scan to maintain state across stream events
         let sse_stream = stream
-            .scan(false, move |content_block_started, result| {
+            .scan(None::<u32>, move |active_block_index, result| {
                 let stream_id = Arc::clone(&stream_id);
                 let model = Arc::clone(&model);
 
@@ -903,7 +909,7 @@ pub async fn messages(
                             event,
                             stream_id.as_str(),
                             model.as_str(),
-                            content_block_started,
+                            active_block_index,
                         );
 
                         anthropic_events
@@ -1405,7 +1411,7 @@ pub async fn messages_passthrough(
             let full_stream = start_event.chain(event_stream);
 
             let sse_stream = full_stream
-                .scan(false, move |content_block_started, result| {
+                .scan(None::<u32>, move |active_block_index, result| {
                     let stream_id = Arc::clone(&stream_id);
                     let model = Arc::clone(&model_arc);
                     let sse_events: Vec<Result<Event, IngressError>> = match result {
@@ -1414,7 +1420,7 @@ pub async fn messages_passthrough(
                                 event,
                                 stream_id.as_str(),
                                 model.as_str(),
-                                content_block_started,
+                                active_block_index,
                             );
                             events
                                 .into_iter()
@@ -2908,7 +2914,7 @@ mod tests {
     fn test_cross_dialect_stream_event_conversion() {
         use lunaroute_core::normalized::Delta;
 
-        let mut content_block_started = false;
+        let mut active_block_index: Option<u32> = None;
 
         let event = NormalizedStreamEvent::Delta {
             index: 0,
@@ -2922,10 +2928,10 @@ mod tests {
             event,
             "msg_test123",
             "@cf/moonshotai/kimi-k2.5",
-            &mut content_block_started,
+            &mut active_block_index,
         );
 
-        assert!(content_block_started);
+        assert_eq!(active_block_index, Some(0));
         assert!(anthropic_events.len() >= 2);
     }
 
@@ -3007,7 +3013,7 @@ mod tests {
     fn test_cross_dialect_stream_error_produces_sse_error_event() {
         use lunaroute_core::normalized::Delta;
 
-        let mut content_block_started = false;
+        let mut active_block_index: Option<u32> = None;
 
         // First send a valid delta to start content block
         let event = NormalizedStreamEvent::Delta {
@@ -3021,9 +3027,9 @@ mod tests {
             event,
             "msg_test",
             "test-model",
-            &mut content_block_started,
+            &mut active_block_index,
         );
-        assert!(content_block_started);
+        assert_eq!(active_block_index, Some(0));
         assert!(!events.is_empty());
 
         // Verify error SSE event can be constructed (matching the cross-dialect error path)
@@ -3162,6 +3168,169 @@ mod tests {
         assert_eq!(
             to_anthropic_tool_id("chatcmpl-abc123"),
             "toolu_chatcmpl-abc123"
+        );
+    }
+
+    #[test]
+    fn test_streaming_tool_call_block_lifecycle() {
+        use lunaroute_core::normalized::{FinishReason, FunctionCallDelta};
+
+        let mut active_block_index: Option<u32> = None;
+
+        // 1. Start event resets state
+        let events = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::Start {
+                id: "msg_test".to_string(),
+                model: "test-model".to_string(),
+            },
+            "msg_test",
+            "test-model",
+            &mut active_block_index,
+        );
+        assert_eq!(active_block_index, None);
+        assert_eq!(events.len(), 1); // message_start
+
+        // 2. Tool call start — should open a block
+        let events = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::ToolCallDelta {
+                index: 0,
+                tool_call_index: 0,
+                id: Some("call_abc".to_string()),
+                function: Some(FunctionCallDelta {
+                    name: Some("Bash".to_string()),
+                    arguments: None,
+                }),
+            },
+            "msg_test",
+            "test-model",
+            &mut active_block_index,
+        );
+        assert_eq!(active_block_index, Some(0));
+        // Should have ContentBlockStart (no prior block to close)
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStart { index: 0, .. }))
+        );
+
+        // 3. Tool call partial JSON
+        let events = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::ToolCallDelta {
+                index: 0,
+                tool_call_index: 0,
+                id: None,
+                function: Some(FunctionCallDelta {
+                    name: None,
+                    arguments: Some("{\"cmd\":\"ls\"}".to_string()),
+                }),
+            },
+            "msg_test",
+            "test-model",
+            &mut active_block_index,
+        );
+        assert_eq!(events.len(), 1); // Just the delta
+        assert!(matches!(
+            &events[0],
+            AnthropicStreamEvent::ContentBlockDelta { index: 0, .. }
+        ));
+
+        // 4. End event — should close the tool block at index 0
+        let events = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::End {
+                finish_reason: FinishReason::ToolCalls,
+            },
+            "msg_test",
+            "test-model",
+            &mut active_block_index,
+        );
+        assert_eq!(active_block_index, None);
+        // Should have ContentBlockStop at index 0, MessageDelta, MessageStop
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStop { index: 0 }))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AnthropicStreamEvent::MessageStop))
+        );
+    }
+
+    #[test]
+    fn test_streaming_text_to_tool_transition() {
+        use lunaroute_core::normalized::{Delta, FinishReason, FunctionCallDelta};
+
+        let mut active_block_index: Option<u32> = None;
+
+        // Start
+        let _ = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::Start {
+                id: "msg_test".to_string(),
+                model: "test-model".to_string(),
+            },
+            "msg_test",
+            "test-model",
+            &mut active_block_index,
+        );
+
+        // Text delta — opens block 0
+        let _ = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::Delta {
+                index: 0,
+                delta: Delta {
+                    role: None,
+                    content: Some("Let me run that.".to_string()),
+                },
+            },
+            "msg_test",
+            "test-model",
+            &mut active_block_index,
+        );
+        assert_eq!(active_block_index, Some(0));
+
+        // Tool call starts — should close text block 0, open tool block 1
+        let events = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::ToolCallDelta {
+                index: 0,
+                tool_call_index: 1,
+                id: Some("call_xyz".to_string()),
+                function: Some(FunctionCallDelta {
+                    name: Some("Bash".to_string()),
+                    arguments: None,
+                }),
+            },
+            "msg_test",
+            "test-model",
+            &mut active_block_index,
+        );
+        assert_eq!(active_block_index, Some(1));
+        // Should have ContentBlockStop for index 0, then ContentBlockStart for index 1
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStop { index: 0 }))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStart { index: 1, .. }))
+        );
+
+        // End — should close tool block 1
+        let events = stream_event_to_anthropic_events(
+            NormalizedStreamEvent::End {
+                finish_reason: FinishReason::ToolCalls,
+            },
+            "msg_test",
+            "test-model",
+            &mut active_block_index,
+        );
+        assert_eq!(active_block_index, None);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AnthropicStreamEvent::ContentBlockStop { index: 1 }))
         );
     }
 }

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -1266,7 +1266,16 @@ pub async fn messages_passthrough(
             let stream_id = Arc::new(format!("msg_{}", uuid::Uuid::new_v4().simple()));
             let model_arc = Arc::new(model.clone());
 
-            let sse_stream = event_stream
+            // OpenAI's stream doesn't emit NormalizedStreamEvent::Start, but Anthropic
+            // clients expect a message_start event. Prepend a synthetic Start event.
+            let start_event =
+                futures::stream::once(futures::future::ready(Ok(NormalizedStreamEvent::Start {
+                    id: stream_id.as_str().to_string(),
+                    model: model_arc.as_str().to_string(),
+                })));
+            let full_stream = start_event.chain(event_stream);
+
+            let sse_stream = full_stream
                 .scan(false, move |content_block_started, result| {
                     let stream_id = Arc::clone(&stream_id);
                     let model = Arc::clone(&model_arc);
@@ -1310,14 +1319,16 @@ pub async fn messages_passthrough(
                 })
                 .flatten();
 
+            let sse_keepalive = if state.sse_keepalive_enabled {
+                KeepAlive::new().interval(std::time::Duration::from_secs(
+                    state.sse_keepalive_interval_secs,
+                ))
+            } else {
+                KeepAlive::new().interval(std::time::Duration::from_secs(86400))
+            };
+
             return Ok(Sse::new(sse_stream)
-                .keep_alive(
-                    KeepAlive::new()
-                        .interval(std::time::Duration::from_secs(
-                            state.sse_keepalive_interval_secs,
-                        ))
-                        .text(""),
-                )
+                .keep_alive(sse_keepalive)
                 .into_response());
         } else {
             let mut normalized = to_normalized(typed_req)?;

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -634,7 +634,7 @@ fn to_anthropic_tool_id(id: &str) -> String {
     let base = if sanitized != id {
         let mut hasher = std::hash::DefaultHasher::new();
         id.hash(&mut hasher);
-        format!("{}_{:04x}", sanitized, hasher.finish() & 0xFFFF)
+        format!("{}_{:08x}", sanitized, hasher.finish() as u32)
     } else {
         sanitized
     };
@@ -1468,6 +1468,10 @@ pub async fn messages_passthrough(
     }
 
     // Cross-dialect routing: Anthropic request → OpenAI provider via normalization
+    // TODO: Add response recording for cross-dialect path (request is already recorded above,
+    // but response/tool-call recording is skipped because this returns early before the
+    // passthrough recording flow). Needs ResponseRecorded event emission for non-streaming
+    // and streaming tool-call tracking for streaming mode.
     if let Some(ref cd_connector) = cross_dialect_connector {
         let typed_req: AnthropicMessagesRequest =
             serde_json::from_value(req.clone()).map_err(|e| {

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -608,11 +608,14 @@ pub fn to_normalized(req: AnthropicMessagesRequest) -> IngressResult<NormalizedR
 
 /// Ensure a tool ID is valid for the Anthropic API (`^[a-zA-Z0-9_-]+$`).
 /// Converts OpenAI-format IDs (e.g. `call_xxx`) to Anthropic-format (`toolu_call_xxx`)
-/// and replaces invalid characters with `_` to preserve position information and
-/// avoid collisions between distinct upstream IDs.
+/// and replaces invalid characters with `_` to preserve position information.
+/// When sanitization alters the ID, appends a 4-char hash of the original to
+/// prevent collisions between distinct upstream IDs that sanitize to the same form.
 /// Avoids double-prefixing IDs that already start with `toolu_`.
 fn to_anthropic_tool_id(id: &str) -> String {
-    // Replace invalid chars with underscore (preserves structure, reduces collision risk)
+    use std::hash::{Hash, Hasher};
+
+    // Replace invalid chars with underscore (preserves structure)
     let sanitized: String = id
         .chars()
         .map(|c| {
@@ -626,11 +629,21 @@ fn to_anthropic_tool_id(id: &str) -> String {
     if sanitized.is_empty() || sanitized.chars().all(|c| c == '_') {
         return format!("toolu_{}", uuid::Uuid::new_v4().simple());
     }
-    // If sanitized ID already has toolu_ prefix, keep it as-is
-    if sanitized.starts_with("toolu_") {
-        sanitized
+
+    // If sanitization changed the ID, append a short hash to prevent collisions
+    let base = if sanitized != id {
+        let mut hasher = std::hash::DefaultHasher::new();
+        id.hash(&mut hasher);
+        format!("{}_{:04x}", sanitized, hasher.finish() & 0xFFFF)
     } else {
-        format!("toolu_{}", sanitized)
+        sanitized
+    };
+
+    // If base already has toolu_ prefix, keep it as-is
+    if base.starts_with("toolu_") {
+        base
+    } else {
+        format!("toolu_{}", base)
     }
 }
 
@@ -818,26 +831,30 @@ fn stream_event_to_anthropic_events(
         } => {
             let mut events = Vec::new();
 
-            // Start tool use block if we have id and name
+            // Start tool use block if we have id and name, and it's not already active
             if let (Some(tool_id), Some(func)) =
                 (id, function.as_ref().and_then(|f| f.name.clone()))
             {
-                // Close previous block if one is active (any type/index transition)
-                if let Some(prev) = *active_block {
-                    let prev_idx = match prev {
-                        ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
-                    };
-                    events.push(AnthropicStreamEvent::ContentBlockStop { index: prev_idx });
-                }
+                let want = ActiveBlock::Tool(tool_call_index);
 
-                events.push(AnthropicStreamEvent::ContentBlockStart {
-                    index: tool_call_index,
-                    content_block: AnthropicContentBlockStart::ToolUse {
-                        id: to_anthropic_tool_id(&tool_id),
-                        name: func,
-                    },
-                });
-                *active_block = Some(ActiveBlock::Tool(tool_call_index));
+                if *active_block != Some(want) {
+                    // Close previous block if one is active (any type/index transition)
+                    if let Some(prev) = *active_block {
+                        let prev_idx = match prev {
+                            ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
+                        };
+                        events.push(AnthropicStreamEvent::ContentBlockStop { index: prev_idx });
+                    }
+
+                    events.push(AnthropicStreamEvent::ContentBlockStart {
+                        index: tool_call_index,
+                        content_block: AnthropicContentBlockStart::ToolUse {
+                            id: to_anthropic_tool_id(&tool_id),
+                            name: func,
+                        },
+                    });
+                    *active_block = Some(want);
+                }
             }
 
             // Send partial JSON only if the matching tool block is active
@@ -3241,37 +3258,44 @@ mod tests {
 
     #[test]
     fn test_to_anthropic_tool_id() {
-        // Already valid Anthropic ID — kept as-is
+        // Already valid Anthropic ID — kept as-is (no hash suffix)
         assert_eq!(to_anthropic_tool_id("toolu_abc123"), "toolu_abc123");
 
-        // OpenAI call_ format — gets toolu_ prefix
+        // OpenAI call_ format — no invalid chars, just prefix (no hash suffix)
         assert_eq!(to_anthropic_tool_id("call_abc123"), "toolu_call_abc123");
 
-        // ID with invalid characters — replaced with _ and prefixed
-        assert_eq!(to_anthropic_tool_id("call.abc:123"), "toolu_call_abc_123");
+        // ID with invalid characters — replaced with _, hash suffix appended
+        let id = to_anthropic_tool_id("call.abc:123");
+        assert!(id.starts_with("toolu_call_abc_123_"));
+        assert!(id.len() > "toolu_call_abc_123_".len()); // has hash suffix
 
         // Empty ID — generates UUID-based ID
         let id = to_anthropic_tool_id("");
         assert!(id.starts_with("toolu_"));
         assert!(id.len() > 6);
 
-        // Hyphenated ID — hyphens are valid
+        // Hyphenated ID — hyphens are valid, no sanitization needed (no hash suffix)
         assert_eq!(
             to_anthropic_tool_id("chatcmpl-abc123"),
             "toolu_chatcmpl-abc123"
         );
 
-        // toolu_ prefix with invalid chars — sanitize but don't double-prefix
-        assert_eq!(
-            to_anthropic_tool_id("toolu_functions.Bash:0"),
-            "toolu_functions_Bash_0"
-        );
+        // toolu_ prefix with invalid chars — sanitize with hash, don't double-prefix
+        let id = to_anthropic_tool_id("toolu_functions.Bash:0");
+        assert!(id.starts_with("toolu_functions_Bash_0_"));
 
-        // Already has toolu_ prefix from upstream — don't double-prefix
+        // Already has toolu_ prefix from upstream, all valid chars — no hash suffix
         assert_eq!(
             to_anthropic_tool_id("toolu_functionsRead0"),
             "toolu_functionsRead0"
         );
+
+        // Collision safety: different upstream IDs that sanitize to same base get
+        // different hash suffixes
+        let id_a = to_anthropic_tool_id("call.a:1");
+        let id_b = to_anthropic_tool_id("call_a_1");
+        // id_b has no invalid chars, so no hash suffix; id_a has invalid chars, gets hash
+        assert_ne!(id_a, id_b);
     }
 
     #[test]

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -886,6 +886,7 @@ pub async fn messages_passthrough(
     // LUNAROUTE marker detection — check for provider override
     let marker_result = crate::marker::extract_marker(&req);
     let mut override_connector: Option<Arc<lunaroute_egress::anthropic::AnthropicConnector>> = None;
+    let mut cross_dialect_connector: Option<Arc<lunaroute_egress::openai::OpenAIConnector>> = None;
     let mut marker_provider_name: Option<String> = None;
 
     match &marker_result {
@@ -893,17 +894,27 @@ pub async fn messages_passthrough(
             if let Some(registry) = &state.provider_registry {
                 if let Some(entry) = registry.get(name) {
                     if entry.connector_type != crate::ProviderType::Anthropic {
-                        tracing::warn!(
-                            "LUNAROUTE marker '{}' targets {:?} provider but request uses Anthropic format",
-                            name,
-                            entry.connector_type
-                        );
-                        return Err(IngressError::InvalidRequest(format!(
-                            "LUNAROUTE marker targets provider '{}' ({:?}) but request uses Anthropic format. Cross-dialect routing requires normalized mode.",
-                            name, entry.connector_type
-                        )));
-                    }
-                    if let Some(ref connector) = entry.anthropic_connector {
+                        // Cross-dialect: Anthropic request → OpenAI provider
+                        if let Some(ref connector) = entry.openai_connector {
+                            tracing::info!(
+                                "LUNAROUTE marker: cross-dialect routing to OpenAI provider '{}', model_override={:?}",
+                                name,
+                                entry.model_override
+                            );
+                            cross_dialect_connector = Some(connector.clone());
+                            marker_provider_name = Some(name.clone());
+
+                            // Apply model override
+                            if let Some(ref model) = entry.model_override {
+                                req["model"] = serde_json::Value::String(model.clone());
+                            }
+                        } else {
+                            tracing::warn!(
+                                "LUNAROUTE marker '{}' targets OpenAI provider but no OpenAI connector available",
+                                name
+                            );
+                        }
+                    } else if let Some(ref connector) = entry.anthropic_connector {
                         tracing::info!(
                             "LUNAROUTE marker: routing to provider '{}', model_override={:?}",
                             name,
@@ -1093,7 +1104,10 @@ pub async fn messages_passthrough(
                 request_id: request_id_clone,
                 timestamp: chrono::Utc::now(),
                 model_requested: model_clone,
-                provider: "anthropic".to_string(),
+                provider: marker_provider_name
+                    .as_deref()
+                    .unwrap_or("anthropic")
+                    .to_string(),
                 listener: "anthropic".to_string(),
                 is_streaming,
                 metadata: V2Metadata {
@@ -1224,6 +1238,33 @@ pub async fn messages_passthrough(
                 }
             }
         });
+    }
+
+    // Cross-dialect routing: Anthropic request → OpenAI provider via normalization
+    if let Some(ref cd_connector) = cross_dialect_connector {
+        let typed_req: AnthropicMessagesRequest =
+            serde_json::from_value(req.clone()).map_err(|e| {
+                IngressError::InvalidRequest(format!(
+                    "Failed to parse request for cross-dialect routing: {}",
+                    e
+                ))
+            })?;
+
+        if is_streaming {
+            // Streaming cross-dialect handled in Task 2
+            todo!("Streaming cross-dialect not yet implemented");
+        } else {
+            let mut normalized = to_normalized(typed_req)?;
+            normalized.stream = false;
+
+            let normalized_resp = cd_connector
+                .send(normalized)
+                .await
+                .map_err(|e| IngressError::ProviderError(e.to_string()))?;
+
+            let anthropic_resp = from_normalized(normalized_resp);
+            return Ok(Json(anthropic_resp).into_response());
+        }
     }
 
     if is_streaming {
@@ -2600,5 +2641,59 @@ mod tests {
         assert_eq!(normalized.tool_results[0].tool_call_id, "toolu_789");
         assert_eq!(normalized.tool_results[0].content, "30");
         assert!(!normalized.tool_results[0].is_error);
+    }
+
+    #[test]
+    fn test_cross_dialect_anthropic_to_normalized_roundtrip() {
+        let raw_json = serde_json::json!({
+            "model": "@cf/moonshotai/kimi-k2.5",
+            "messages": [
+                {"role": "user", "content": "Hello from Claude Code"}
+            ],
+            "max_tokens": 1024,
+            "stream": false
+        });
+
+        let typed_req: AnthropicMessagesRequest = serde_json::from_value(raw_json).unwrap();
+        assert_eq!(typed_req.model, "@cf/moonshotai/kimi-k2.5");
+
+        let mut normalized = to_normalized(typed_req).unwrap();
+        normalized.stream = false;
+        assert_eq!(normalized.model, "@cf/moonshotai/kimi-k2.5");
+        assert_eq!(normalized.messages.len(), 1);
+        assert!(!normalized.stream);
+
+        let normalized_resp = NormalizedResponse {
+            id: "chatcmpl-test".to_string(),
+            model: "@cf/moonshotai/kimi-k2.5".to_string(),
+            choices: vec![Choice {
+                index: 0,
+                message: Message {
+                    role: Role::Assistant,
+                    content: MessageContent::Text("Hello from Kimi".to_string()),
+                    name: None,
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                },
+                finish_reason: Some(FinishReason::Stop),
+            }],
+            usage: Usage {
+                prompt_tokens: 5,
+                completion_tokens: 3,
+                total_tokens: 8,
+            },
+            created: 1234567890,
+            metadata: std::collections::HashMap::new(),
+        };
+
+        let anthropic_resp = from_normalized(normalized_resp);
+        assert_eq!(anthropic_resp.model, "@cf/moonshotai/kimi-k2.5");
+        assert_eq!(anthropic_resp.role, "assistant");
+        assert_eq!(anthropic_resp.stop_reason, Some("end_turn".to_string()));
+        assert!(!anthropic_resp.content.is_empty());
+        match &anthropic_resp.content[0] {
+            AnthropicContent::Text { text } => assert_eq!(text, "Hello from Kimi"),
+            _ => panic!("Expected text content"),
+        }
     }
 }

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -197,7 +197,7 @@ impl<'de> serde::Deserialize<'de> for AnthropicContentBlock {
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| serde::de::Error::missing_field("tool_use_id"))?
                     .to_string();
-                // Content can be either a string or an array of content blocks
+                // Content can be a string, an array of content blocks, or absent (null/missing)
                 let content = match value.get("content") {
                     Some(serde_json::Value::String(s)) => s.clone(),
                     Some(serde_json::Value::Array(arr)) => arr
@@ -211,7 +211,13 @@ impl<'de> serde::Deserialize<'de> for AnthropicContentBlock {
                         })
                         .collect::<Vec<_>>()
                         .join("\n"),
-                    _ => String::new(),
+                    Some(serde_json::Value::Null) | None => String::new(),
+                    Some(other) => {
+                        return Err(serde::de::Error::custom(format!(
+                            "tool_result.content must be a string, array, or null; got {}",
+                            other
+                        )));
+                    }
                 };
                 let is_error = value.get("is_error").and_then(|v| v.as_bool());
                 Ok(Self::ToolResult {
@@ -513,8 +519,14 @@ pub fn to_normalized(req: AnthropicMessagesRequest) -> IngressResult<NormalizedR
                                     tool_name: None, // Will be filled in by SessionRecorder
                                 });
                             }
-                            AnthropicContentBlock::Unknown(_) => {
-                                // Skip unknown block types (thinking, image, etc.)
+                            AnthropicContentBlock::Unknown(ref val) => {
+                                // Skip unknown block types (thinking, redacted_thinking, image, etc.)
+                                tracing::debug!(
+                                    "Skipping unknown content block type during normalization: {}",
+                                    val.get("type")
+                                        .and_then(|t| t.as_str())
+                                        .unwrap_or("unknown")
+                                );
                             }
                         }
                     }
@@ -714,25 +726,33 @@ pub fn from_normalized(resp: NormalizedResponse) -> AnthropicResponse {
     }
 }
 
+/// Tracks the currently active content block in a streaming Anthropic response.
+/// Ensures proper Start→Delta→Stop sequencing and correct transitions between block types.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ActiveBlock {
+    Text(u32),
+    Tool(u32),
+}
+
 /// Convert normalized stream event to Anthropic SSE events
 /// Returns a vector because some normalized events map to multiple Anthropic events
 ///
 /// State Management:
-/// - `active_block_index` tracks the index of the currently open ContentBlock
-/// - `None` means no block is open; `Some(i)` means block `i` needs a Stop event
-/// - This ensures proper event sequencing: Start → Delta → Stop for both text and tool blocks
+/// - `active_block` tracks both the type and index of the currently open ContentBlock
+/// - `None` means no block is open; `Some(ActiveBlock::*)` means that block needs a Stop event
+/// - On type/index changes, the previous block is closed before the new one opens
 /// - State is maintained per-stream via scan() combinator (sequential, no concurrency)
 fn stream_event_to_anthropic_events(
     event: NormalizedStreamEvent,
     stream_id: &str,
     model: &str,
-    active_block_index: &mut Option<u32>,
+    active_block: &mut Option<ActiveBlock>,
 ) -> Vec<AnthropicStreamEvent> {
     use tracing::debug;
     match event {
         NormalizedStreamEvent::Start { .. } => {
             // Reset state for new stream
-            *active_block_index = None;
+            *active_block = None;
             debug!("Anthropic stream started: stream_id={}", stream_id);
 
             // Anthropic starts with message_start event
@@ -753,16 +773,28 @@ fn stream_event_to_anthropic_events(
         }
         NormalizedStreamEvent::Delta { index, delta } => {
             let mut events = Vec::new();
+            let want = ActiveBlock::Text(index);
 
-            // For first delta, send content_block_start
-            if active_block_index.is_none() {
+            // If a different block is active, close it first
+            if let Some(prev) = *active_block
+                && prev != want
+            {
+                let prev_idx = match prev {
+                    ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
+                };
+                events.push(AnthropicStreamEvent::ContentBlockStop { index: prev_idx });
+                *active_block = None;
+            }
+
+            // Open text block if not already active
+            if active_block.is_none() {
                 events.push(AnthropicStreamEvent::ContentBlockStart {
                     index,
                     content_block: AnthropicContentBlockStart::Text {
                         text: String::new(),
                     },
                 });
-                *active_block_index = Some(index);
+                *active_block = Some(want);
             }
 
             // Send the text delta
@@ -787,8 +819,11 @@ fn stream_event_to_anthropic_events(
             if let (Some(tool_id), Some(func)) =
                 (id, function.as_ref().and_then(|f| f.name.clone()))
             {
-                // Close previous block if one is active (e.g. text → tool transition)
-                if let Some(prev_idx) = *active_block_index {
+                // Close previous block if one is active (any type/index transition)
+                if let Some(prev) = *active_block {
+                    let prev_idx = match prev {
+                        ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
+                    };
                     events.push(AnthropicStreamEvent::ContentBlockStop { index: prev_idx });
                 }
 
@@ -799,7 +834,7 @@ fn stream_event_to_anthropic_events(
                         name: func,
                     },
                 });
-                *active_block_index = Some(tool_call_index);
+                *active_block = Some(ActiveBlock::Tool(tool_call_index));
             }
 
             // Send partial JSON if available
@@ -820,7 +855,10 @@ fn stream_event_to_anthropic_events(
             let mut events = Vec::new();
 
             // Close whichever content block is currently active (text or tool)
-            if let Some(idx) = active_block_index.take() {
+            if let Some(prev) = active_block.take() {
+                let idx = match prev {
+                    ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
+                };
                 events.push(AnthropicStreamEvent::ContentBlockStop { index: idx });
                 debug!("Anthropic content block {} closed", idx);
             } else {
@@ -899,7 +937,7 @@ pub async fn messages(
         // Convert normalized events to Anthropic SSE format
         // Use scan to maintain state across stream events
         let sse_stream = stream
-            .scan(None::<u32>, move |active_block_index, result| {
+            .scan(None::<ActiveBlock>, move |active_block, result| {
                 let stream_id = Arc::clone(&stream_id);
                 let model = Arc::clone(&model);
 
@@ -909,7 +947,7 @@ pub async fn messages(
                             event,
                             stream_id.as_str(),
                             model.as_str(),
-                            active_block_index,
+                            active_block,
                         );
 
                         anthropic_events
@@ -1411,7 +1449,7 @@ pub async fn messages_passthrough(
             let full_stream = start_event.chain(event_stream);
 
             let sse_stream = full_stream
-                .scan(None::<u32>, move |active_block_index, result| {
+                .scan(None::<ActiveBlock>, move |active_block, result| {
                     let stream_id = Arc::clone(&stream_id);
                     let model = Arc::clone(&model_arc);
                     let sse_events: Vec<Result<Event, IngressError>> = match result {
@@ -1420,7 +1458,7 @@ pub async fn messages_passthrough(
                                 event,
                                 stream_id.as_str(),
                                 model.as_str(),
-                                active_block_index,
+                                active_block,
                             );
                             events
                                 .into_iter()
@@ -2914,7 +2952,7 @@ mod tests {
     fn test_cross_dialect_stream_event_conversion() {
         use lunaroute_core::normalized::Delta;
 
-        let mut active_block_index: Option<u32> = None;
+        let mut active_block: Option<ActiveBlock> = None;
 
         let event = NormalizedStreamEvent::Delta {
             index: 0,
@@ -2928,10 +2966,10 @@ mod tests {
             event,
             "msg_test123",
             "@cf/moonshotai/kimi-k2.5",
-            &mut active_block_index,
+            &mut active_block,
         );
 
-        assert_eq!(active_block_index, Some(0));
+        assert_eq!(active_block, Some(ActiveBlock::Text(0)));
         assert!(anthropic_events.len() >= 2);
     }
 
@@ -3013,7 +3051,7 @@ mod tests {
     fn test_cross_dialect_stream_error_produces_sse_error_event() {
         use lunaroute_core::normalized::Delta;
 
-        let mut active_block_index: Option<u32> = None;
+        let mut active_block: Option<ActiveBlock> = None;
 
         // First send a valid delta to start content block
         let event = NormalizedStreamEvent::Delta {
@@ -3023,13 +3061,9 @@ mod tests {
                 content: Some("partial".to_string()),
             },
         };
-        let events = stream_event_to_anthropic_events(
-            event,
-            "msg_test",
-            "test-model",
-            &mut active_block_index,
-        );
-        assert_eq!(active_block_index, Some(0));
+        let events =
+            stream_event_to_anthropic_events(event, "msg_test", "test-model", &mut active_block);
+        assert_eq!(active_block, Some(ActiveBlock::Text(0)));
         assert!(!events.is_empty());
 
         // Verify error SSE event can be constructed (matching the cross-dialect error path)
@@ -3175,7 +3209,7 @@ mod tests {
     fn test_streaming_tool_call_block_lifecycle() {
         use lunaroute_core::normalized::{FinishReason, FunctionCallDelta};
 
-        let mut active_block_index: Option<u32> = None;
+        let mut active_block: Option<ActiveBlock> = None;
 
         // 1. Start event resets state
         let events = stream_event_to_anthropic_events(
@@ -3185,9 +3219,9 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block_index,
+            &mut active_block,
         );
-        assert_eq!(active_block_index, None);
+        assert_eq!(active_block, None);
         assert_eq!(events.len(), 1); // message_start
 
         // 2. Tool call start — should open a block
@@ -3203,9 +3237,9 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block_index,
+            &mut active_block,
         );
-        assert_eq!(active_block_index, Some(0));
+        assert_eq!(active_block, Some(ActiveBlock::Tool(0)));
         // Should have ContentBlockStart (no prior block to close)
         assert!(
             events
@@ -3226,7 +3260,7 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block_index,
+            &mut active_block,
         );
         assert_eq!(events.len(), 1); // Just the delta
         assert!(matches!(
@@ -3241,9 +3275,9 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block_index,
+            &mut active_block,
         );
-        assert_eq!(active_block_index, None);
+        assert_eq!(active_block, None);
         // Should have ContentBlockStop at index 0, MessageDelta, MessageStop
         assert!(
             events
@@ -3261,7 +3295,7 @@ mod tests {
     fn test_streaming_text_to_tool_transition() {
         use lunaroute_core::normalized::{Delta, FinishReason, FunctionCallDelta};
 
-        let mut active_block_index: Option<u32> = None;
+        let mut active_block: Option<ActiveBlock> = None;
 
         // Start
         let _ = stream_event_to_anthropic_events(
@@ -3271,7 +3305,7 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block_index,
+            &mut active_block,
         );
 
         // Text delta — opens block 0
@@ -3285,9 +3319,9 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block_index,
+            &mut active_block,
         );
-        assert_eq!(active_block_index, Some(0));
+        assert_eq!(active_block, Some(ActiveBlock::Text(0)));
 
         // Tool call starts — should close text block 0, open tool block 1
         let events = stream_event_to_anthropic_events(
@@ -3302,9 +3336,9 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block_index,
+            &mut active_block,
         );
-        assert_eq!(active_block_index, Some(1));
+        assert_eq!(active_block, Some(ActiveBlock::Tool(1)));
         // Should have ContentBlockStop for index 0, then ContentBlockStart for index 1
         assert!(
             events
@@ -3324,9 +3358,9 @@ mod tests {
             },
             "msg_test",
             "test-model",
-            &mut active_block_index,
+            &mut active_block,
         );
-        assert_eq!(active_block_index, None);
+        assert_eq!(active_block, None);
         assert!(
             events
                 .iter()

--- a/crates/lunaroute-ingress/src/anthropic.rs
+++ b/crates/lunaroute-ingress/src/anthropic.rs
@@ -608,15 +608,22 @@ pub fn to_normalized(req: AnthropicMessagesRequest) -> IngressResult<NormalizedR
 
 /// Ensure a tool ID is valid for the Anthropic API (`^[a-zA-Z0-9_-]+$`).
 /// Converts OpenAI-format IDs (e.g. `call_xxx`) to Anthropic-format (`toolu_call_xxx`)
-/// and strips any characters outside the allowed set.
+/// and replaces invalid characters with `_` to preserve position information and
+/// avoid collisions between distinct upstream IDs.
 /// Avoids double-prefixing IDs that already start with `toolu_`.
 fn to_anthropic_tool_id(id: &str) -> String {
-    // Sanitize first: keep only valid chars
+    // Replace invalid chars with underscore (preserves structure, reduces collision risk)
     let sanitized: String = id
         .chars()
-        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
-    if sanitized.is_empty() {
+    if sanitized.is_empty() || sanitized.chars().all(|c| c == '_') {
         return format!("toolu_{}", uuid::Uuid::new_v4().simple());
     }
     // If sanitized ID already has toolu_ prefix, keep it as-is
@@ -965,20 +972,43 @@ pub async fn messages(
                             .collect::<Vec<_>>()
                     }
                     Err(e) => {
+                        let mut error_events = Vec::new();
+
+                        // Close any active content block before the error
+                        if let Some(prev) = active_block.take() {
+                            let idx = match prev {
+                                ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
+                            };
+                            if let Ok(evt) = Event::default()
+                                .json_data(AnthropicStreamEvent::ContentBlockStop { index: idx })
+                            {
+                                error_events.push(Ok(evt));
+                            }
+                        }
+
                         // Send error event
-                        let error_event = serde_json::json!({
+                        let error_payload = serde_json::json!({
                             "type": "error",
                             "error": {
                                 "type": "api_error",
                                 "message": e.to_string()
                             }
                         });
-                        match Event::default().json_data(error_event) {
-                            Ok(event) => vec![Ok(event)],
-                            Err(_) => vec![Err(IngressError::Internal(
+                        match Event::default().json_data(error_payload) {
+                            Ok(event) => error_events.push(Ok(event)),
+                            Err(_) => error_events.push(Err(IngressError::Internal(
                                 "Failed to create error SSE event".to_string(),
-                            ))],
+                            ))),
                         }
+
+                        // Send message_stop to properly terminate the stream
+                        if let Ok(evt) =
+                            Event::default().json_data(AnthropicStreamEvent::MessageStop)
+                        {
+                            error_events.push(Ok(evt));
+                        }
+
+                        error_events
                     }
                 };
 
@@ -1476,19 +1506,43 @@ pub async fn messages_passthrough(
                         }
                         Err(e) => {
                             tracing::error!("Cross-dialect stream error: {}", e);
-                            let error_event = serde_json::json!({
+                            let mut error_events = Vec::new();
+
+                            // Close any active content block before the error
+                            if let Some(prev) = active_block.take() {
+                                let idx = match prev {
+                                    ActiveBlock::Text(i) | ActiveBlock::Tool(i) => i,
+                                };
+                                if let Ok(evt) = Event::default().json_data(
+                                    AnthropicStreamEvent::ContentBlockStop { index: idx },
+                                ) {
+                                    error_events.push(Ok(evt));
+                                }
+                            }
+
+                            // Send the error event
+                            let error_payload = serde_json::json!({
                                 "type": "error",
                                 "error": {
                                     "type": "api_error",
                                     "message": e.to_string()
                                 }
                             });
-                            match Event::default().json_data(error_event) {
-                                Ok(event) => vec![Ok(event)],
-                                Err(_) => vec![Err(IngressError::Internal(
+                            match Event::default().json_data(error_payload) {
+                                Ok(event) => error_events.push(Ok(event)),
+                                Err(_) => error_events.push(Err(IngressError::Internal(
                                     "Failed to create error SSE event".to_string(),
-                                ))],
+                                ))),
                             }
+
+                            // Send message_stop to properly terminate the stream
+                            if let Ok(evt) =
+                                Event::default().json_data(AnthropicStreamEvent::MessageStop)
+                            {
+                                error_events.push(Ok(evt));
+                            }
+
+                            error_events
                         }
                     };
                     futures::future::ready(Some(futures::stream::iter(sse_events)))
@@ -3193,8 +3247,8 @@ mod tests {
         // OpenAI call_ format — gets toolu_ prefix
         assert_eq!(to_anthropic_tool_id("call_abc123"), "toolu_call_abc123");
 
-        // ID with invalid characters — stripped and prefixed
-        assert_eq!(to_anthropic_tool_id("call.abc:123"), "toolu_callabc123");
+        // ID with invalid characters — replaced with _ and prefixed
+        assert_eq!(to_anthropic_tool_id("call.abc:123"), "toolu_call_abc_123");
 
         // Empty ID — generates UUID-based ID
         let id = to_anthropic_tool_id("");
@@ -3210,7 +3264,7 @@ mod tests {
         // toolu_ prefix with invalid chars — sanitize but don't double-prefix
         assert_eq!(
             to_anthropic_tool_id("toolu_functions.Bash:0"),
-            "toolu_functionsBash0"
+            "toolu_functions_Bash_0"
         );
 
         // Already has toolu_ prefix from upstream — don't double-prefix

--- a/crates/lunaroute-ingress/src/marker.rs
+++ b/crates/lunaroute-ingress/src/marker.rs
@@ -16,34 +16,63 @@ pub enum MarkerResult {
     None,
 }
 
-/// Scan a request body (serde_json::Value) for [LUNAROUTE:xxx] marker.
-/// Searches the LAST user message only — old markers from previous turns
-/// may persist in conversation history and must be ignored.
-/// Returns the first marker found in the last user message.
-/// Logs a warning if multiple markers exist.
-pub fn extract_marker(req: &serde_json::Value) -> MarkerResult {
-    let mut found: Vec<String> = Vec::new();
+/// Check if a user message contains only tool_result blocks (no text content).
+fn is_tool_result_only(msg: &serde_json::Value) -> bool {
+    if let Some(content_arr) = msg.get("content").and_then(|c| c.as_array()) {
+        !content_arr.is_empty()
+            && content_arr
+                .iter()
+                .all(|b| b.get("type").and_then(|t| t.as_str()) == Some("tool_result"))
+    } else {
+        false
+    }
+}
 
-    if let Some(messages) = req.get("messages").and_then(|m| m.as_array()) {
-        let last_user_msg = messages
-            .iter()
-            .rev()
-            .find(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("user"));
-
-        if let Some(msg) = last_user_msg {
-            if let Some(content_arr) = msg.get("content").and_then(|c| c.as_array()) {
-                for block in content_arr {
-                    if let Some(text) = block.get("text").and_then(|t| t.as_str())
-                        && let Some(caps) = MARKER_EXTRACT_RE.captures(text)
-                    {
-                        found.push(caps[1].to_string());
-                    }
-                }
-            } else if let Some(text) = msg.get("content").and_then(|c| c.as_str())
+/// Try to extract a LUNAROUTE marker from a single message.
+fn extract_marker_from_msg(msg: &serde_json::Value) -> Vec<String> {
+    let mut found = Vec::new();
+    if let Some(content_arr) = msg.get("content").and_then(|c| c.as_array()) {
+        for block in content_arr {
+            if let Some(text) = block.get("text").and_then(|t| t.as_str())
                 && let Some(caps) = MARKER_EXTRACT_RE.captures(text)
             {
                 found.push(caps[1].to_string());
             }
+        }
+    } else if let Some(text) = msg.get("content").and_then(|c| c.as_str())
+        && let Some(caps) = MARKER_EXTRACT_RE.captures(text)
+    {
+        found.push(caps[1].to_string());
+    }
+    found
+}
+
+/// Scan a request body (serde_json::Value) for [LUNAROUTE:xxx] marker.
+///
+/// Searches the last user message first. If that message contains only
+/// tool_result blocks (an automatic follow-up to a tool call), walks back
+/// through earlier user messages to inherit routing from the message that
+/// triggered the tool call chain. This ensures multi-step tool calling
+/// stays on the same provider.
+///
+/// Returns the first marker found. Logs a warning if multiple markers exist.
+pub fn extract_marker(req: &serde_json::Value) -> MarkerResult {
+    let mut found: Vec<String> = Vec::new();
+
+    if let Some(messages) = req.get("messages").and_then(|m| m.as_array()) {
+        // Walk user messages from the end
+        for msg in messages.iter().rev() {
+            if msg.get("role").and_then(|r| r.as_str()) != Some("user") {
+                continue;
+            }
+
+            // If this is a tool-result-only message, skip it and keep looking back
+            if is_tool_result_only(msg) {
+                continue;
+            }
+
+            found = extract_marker_from_msg(msg);
+            break;
         }
     }
 
@@ -428,6 +457,111 @@ mod tests {
         strip_marker(&mut req);
 
         assert_eq!(req["model"], "claude-sonnet-4-20250514");
+        assert_eq!(extract_marker(&req), MarkerResult::None);
+    }
+
+    #[test]
+    fn test_extract_marker_skips_tool_result_messages() {
+        // Simulates: user sends #!kimik25, model responds with tool_use,
+        // Claude Code sends tool_result. The marker should be inherited
+        // from the earlier user message.
+        let req = json!({
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "<system-reminder>\n[LUNAROUTE:kimik25]\n</system-reminder>"},
+                        {"type": "text", "text": "list files #!kimik25"}
+                    ]
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "toolu_functionsBash0", "name": "Bash", "input": {"command": "ls"}}
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_functionsBash0", "content": "file1.txt\nfile2.txt"}
+                    ]
+                }
+            ]
+        });
+        assert_eq!(
+            extract_marker(&req),
+            MarkerResult::Provider("kimik25".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_marker_skips_multiple_tool_result_rounds() {
+        // Multiple tool-call rounds: marker should still be found
+        let req = json!({
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "[LUNAROUTE:kimik25]"},
+                        {"type": "text", "text": "create and cat a file"}
+                    ]
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}]
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "t2", "name": "Bash", "input": {}}]
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "t2", "content": "ok"}]
+                }
+            ]
+        });
+        assert_eq!(
+            extract_marker(&req),
+            MarkerResult::Provider("kimik25".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_marker_no_inherit_when_new_text_message() {
+        // If the user sends a new text message after tool results,
+        // only the new message matters (no stale marker inheritance).
+        let req = json!({
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "[LUNAROUTE:kimik25]"},
+                        {"type": "text", "text": "do something"}
+                    ]
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}]
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Done!"}]
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "now do something else"}]
+                }
+            ]
+        });
+        // New text message without marker — should NOT inherit kimik25
         assert_eq!(extract_marker(&req), MarkerResult::None);
     }
 }

--- a/crates/lunaroute-ingress/src/marker.rs
+++ b/crates/lunaroute-ingress/src/marker.rs
@@ -104,7 +104,8 @@ static INLINE_STRIP_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[LUNAROUTE:[a-zA-Z0-9._-]+\]").unwrap());
 
 /// Remove [LUNAROUTE:xxx] marker text from the request body.
-/// Operates on the LAST user message only (matching extract_marker's scope).
+/// Uses the same message selection logic as extract_marker: walks backward
+/// from the end, skipping tool-result-only user messages.
 /// - Standalone content block (entire text is system-reminder with marker): remove block.
 /// - Inline in a larger text block: regex-replace the marker text.
 /// - String content: regex-replace within the string.
@@ -115,12 +116,21 @@ pub fn strip_marker(req: &mut serde_json::Value) {
         return;
     };
 
-    // Find the index of the last user message
-    let last_user_idx = messages
-        .iter()
-        .rposition(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("user"));
+    // Find the target user message using the same logic as extract_marker:
+    // walk backwards, skipping tool-result-only user messages.
+    let mut target_idx = None;
+    for (i, msg) in messages.iter().enumerate().rev() {
+        if msg.get("role").and_then(|r| r.as_str()) != Some("user") {
+            continue;
+        }
+        if is_tool_result_only(msg) {
+            continue;
+        }
+        target_idx = Some(i);
+        break;
+    }
 
-    let Some(idx) = last_user_idx else { return };
+    let Some(idx) = target_idx else { return };
     let msg = &mut messages[idx];
 
     // Handle array content
@@ -563,5 +573,51 @@ mod tests {
         });
         // New text message without marker — should NOT inherit kimik25
         assert_eq!(extract_marker(&req), MarkerResult::None);
+    }
+
+    #[test]
+    fn test_strip_marker_skips_tool_result_messages() {
+        // strip_marker should target the same message as extract_marker:
+        // skip trailing tool-result-only user messages.
+        let mut req = json!({
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "<system-reminder>\n[LUNAROUTE:kimik25]\n</system-reminder>"},
+                        {"type": "text", "text": "list files"}
+                    ]
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}]
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+                }
+            ]
+        });
+
+        // Extract should find the marker in the first user message
+        assert_eq!(
+            extract_marker(&req),
+            MarkerResult::Provider("kimik25".to_string())
+        );
+
+        // Strip should also target the first user message (not the tool_result message)
+        strip_marker(&mut req);
+
+        // Marker should be gone from the first user message
+        assert_eq!(extract_marker(&req), MarkerResult::None);
+
+        // First user message should still have text content
+        let content = req["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["text"], "list files");
+
+        // Tool result message should be untouched
+        let tool_msg = &req["messages"][2]["content"];
+        assert!(tool_msg.as_array().unwrap()[0].get("tool_use_id").is_some());
     }
 }

--- a/crates/lunaroute-server/src/config.rs
+++ b/crates/lunaroute-server/src/config.rs
@@ -516,10 +516,11 @@ impl ServerConfig {
         let path = path.as_ref();
         let contents = std::fs::read_to_string(path)?;
 
-        // Expand environment variables (${VAR}) and tilde (~) in the raw config
-        let contents = shellexpand::full(&contents)
-            .map_err(|e| format!("Failed to expand environment variables in config: {}", e))?
-            .to_string();
+        // Expand environment variables (${VAR}) in the raw config.
+        // Uses non-failing mode: unresolved vars (e.g. in comments) are left as-is.
+        let contents =
+            shellexpand::env_with_context_no_errors(&contents, |var: &str| std::env::var(var).ok())
+                .to_string();
 
         let mut config: ServerConfig = if path.extension().and_then(|s| s.to_str()) == Some("toml")
         {

--- a/crates/lunaroute-server/src/config.rs
+++ b/crates/lunaroute-server/src/config.rs
@@ -516,6 +516,11 @@ impl ServerConfig {
         let path = path.as_ref();
         let contents = std::fs::read_to_string(path)?;
 
+        // Expand environment variables (${VAR}) and tilde (~) in the raw config
+        let contents = shellexpand::full(&contents)
+            .map_err(|e| format!("Failed to expand environment variables in config: {}", e))?
+            .to_string();
+
         let mut config: ServerConfig = if path.extension().and_then(|s| s.to_str()) == Some("toml")
         {
             toml::from_str(&contents)?

--- a/docs/superpowers/plans/2026-04-03-cross-dialect-marker-routing.md
+++ b/docs/superpowers/plans/2026-04-03-cross-dialect-marker-routing.md
@@ -1,0 +1,469 @@
+# Cross-Dialect Marker Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable LUNAROUTE marker routing from Anthropic-format requests to OpenAI-type providers (e.g., Claude Code → Kimi K2.5 on Cloudflare).
+
+**Architecture:** When `messages_passthrough()` detects a cross-dialect marker, parse the Anthropic JSON into typed form, normalize, send via the OpenAI connector's `Provider` trait, and convert the response back to Anthropic format. All building blocks exist; this is wiring.
+
+**Tech Stack:** Rust, axum, serde_json, lunaroute-core normalization, lunaroute-egress Provider trait
+
+**Spec:** `docs/superpowers/specs/2026-04-03-cross-dialect-marker-routing-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `crates/lunaroute-ingress/src/anthropic.rs` | Modify (lines 888-938, 1096) | Cross-dialect routing in passthrough handler, session recording provider field |
+| `examples/configs/private/eran.yaml` | Modify (kimik25 section) | Add model override |
+
+---
+
+### Task 1: Add non-streaming cross-dialect routing
+
+**Files:**
+- Modify: `crates/lunaroute-ingress/src/anthropic.rs:888-938` (marker match block)
+- Modify: `crates/lunaroute-ingress/src/anthropic.rs:1096` (session recording provider field)
+- Test: `crates/lunaroute-ingress/src/anthropic.rs` (inline tests module at line 1870)
+
+- [ ] **Step 1: Write failing test for cross-dialect non-streaming**
+
+In `crates/lunaroute-ingress/src/anthropic.rs`, inside the existing `mod tests` block (line 1870), add a test that verifies Anthropic JSON can be parsed, normalized, sent through a mock OpenAI Provider, and converted back to Anthropic format. This tests the conversion pipeline, not the handler itself.
+
+```rust
+#[test]
+fn test_cross_dialect_anthropic_to_normalized_roundtrip() {
+    // Simulate what the cross-dialect path does:
+    // 1. Raw Anthropic JSON → AnthropicMessagesRequest
+    // 2. to_normalized() → NormalizedRequest
+    // 3. from_normalized(NormalizedResponse) → AnthropicResponse
+
+    let raw_json = serde_json::json!({
+        "model": "@cf/moonshotai/kimi-k2.5",
+        "messages": [
+            {"role": "user", "content": "Hello from Claude Code"}
+        ],
+        "max_tokens": 1024,
+        "stream": false
+    });
+
+    // Step 1: Parse raw JSON into typed Anthropic request
+    let typed_req: AnthropicMessagesRequest = serde_json::from_value(raw_json).unwrap();
+    assert_eq!(typed_req.model, "@cf/moonshotai/kimi-k2.5");
+
+    // Step 2: Normalize
+    let mut normalized = to_normalized(typed_req).unwrap();
+    normalized.stream = false;
+    assert_eq!(normalized.model, "@cf/moonshotai/kimi-k2.5");
+    assert_eq!(normalized.messages.len(), 1);
+    assert!(!normalized.stream);
+
+    // Step 3: Simulate provider response and convert back
+    let normalized_resp = NormalizedResponse {
+        id: "chatcmpl-test".to_string(),
+        model: "@cf/moonshotai/kimi-k2.5".to_string(),
+        choices: vec![Choice {
+            index: 0,
+            message: Message {
+                role: Role::Assistant,
+                content: MessageContent::Text("Hello from Kimi".to_string()),
+                name: None,
+                tool_calls: vec![],
+                tool_call_id: None,
+            },
+            finish_reason: Some(FinishReason::Stop),
+        }],
+        usage: Usage {
+            prompt_tokens: 5,
+            completion_tokens: 3,
+            total_tokens: 8,
+        },
+        created: 1234567890,
+        metadata: std::collections::HashMap::new(),
+    };
+
+    let anthropic_resp = from_normalized(normalized_resp);
+    assert_eq!(anthropic_resp.model, "@cf/moonshotai/kimi-k2.5");
+    assert_eq!(anthropic_resp.role, "assistant");
+    assert_eq!(anthropic_resp.stop_reason, Some("end_turn".to_string()));
+    // Verify content is preserved
+    assert!(!anthropic_resp.content.is_empty());
+    match &anthropic_resp.content[0] {
+        AnthropicContent::Text { text } => assert_eq!(text, "Hello from Kimi"),
+        _ => panic!("Expected text content"),
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+This is a pure conversion test that exercises existing code — it should pass immediately since `to_normalized()` and `from_normalized()` already exist.
+
+Run: `cargo test -p lunaroute-ingress -- test_cross_dialect_anthropic_to_normalized_roundtrip -v`
+Expected: PASS
+
+- [ ] **Step 3: Add cross-dialect variable and modify marker match block**
+
+In `crates/lunaroute-ingress/src/anthropic.rs`, at line 888, add a new variable alongside the existing `override_connector` and `marker_provider_name`:
+
+```rust
+let mut override_connector: Option<Arc<lunaroute_egress::anthropic::AnthropicConnector>> = None;
+let mut cross_dialect_connector: Option<Arc<lunaroute_egress::openai::OpenAIConnector>> = None;
+let mut marker_provider_name: Option<String> = None;
+```
+
+Then replace lines 895-904 (the error block) with cross-dialect handling:
+
+```rust
+if entry.connector_type != crate::ProviderType::Anthropic {
+    // Cross-dialect: Anthropic request → OpenAI provider
+    if let Some(ref connector) = entry.openai_connector {
+        tracing::info!(
+            "LUNAROUTE marker: cross-dialect routing to OpenAI provider '{}', model_override={:?}",
+            name,
+            entry.model_override
+        );
+        cross_dialect_connector = Some(connector.clone());
+        marker_provider_name = Some(name.clone());
+
+        // Apply model override
+        if let Some(ref model) = entry.model_override {
+            req["model"] = serde_json::Value::String(model.clone());
+        }
+    } else {
+        tracing::warn!(
+            "LUNAROUTE marker '{}' targets OpenAI provider but no OpenAI connector available",
+            name
+        );
+    }
+} else {
+    // Same-dialect: existing Anthropic→Anthropic logic (unchanged)
+    if let Some(ref connector) = entry.anthropic_connector {
+```
+
+Note: the existing same-dialect code (lines 906-918) stays inside the `else` block. The closing braces need to be adjusted.
+
+- [ ] **Step 4: Add cross-dialect early return for non-streaming**
+
+After the session recording block (after line 1227) and before the existing `if is_streaming {` block (line 1229), add the cross-dialect early return:
+
+```rust
+// Cross-dialect routing: Anthropic request → OpenAI provider via normalization
+// Note: Provider trait is already imported at file scope (line 21)
+if let Some(ref cd_connector) = cross_dialect_connector {
+    let typed_req: AnthropicMessagesRequest = serde_json::from_value(req.clone())
+        .map_err(|e| IngressError::InvalidRequest(
+            format!("Failed to parse request for cross-dialect routing: {}", e)
+        ))?;
+
+    if is_streaming {
+        // Streaming cross-dialect handled in Task 2
+        todo!("Streaming cross-dialect not yet implemented");
+    } else {
+        let mut normalized = to_normalized(typed_req)?;
+        normalized.stream = false;
+
+        let normalized_resp = cd_connector.send(normalized).await
+            .map_err(|e| IngressError::ProviderError(e.to_string()))?;
+
+        let anthropic_resp = from_normalized(normalized_resp);
+        return Ok(Json(anthropic_resp).into_response());
+    }
+}
+```
+
+- [ ] **Step 5: Fix session recording provider field**
+
+At line 1096, change the hardcoded provider string:
+
+```rust
+// Before:
+provider: "anthropic".to_string(),
+
+// After:
+provider: marker_provider_name.as_deref().unwrap_or("anthropic").to_string(),
+```
+
+The `listener` field on line 1097 stays `"anthropic"`.
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cargo check -p lunaroute-ingress`
+Expected: Compiles with no errors (may have a warning about the `todo!()` in streaming path)
+
+- [ ] **Step 7: Run all existing tests**
+
+Run: `cargo test -p lunaroute-ingress`
+Expected: All existing tests pass. The new test from Step 1 passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/lunaroute-ingress/src/anthropic.rs
+git commit -m "feat: add non-streaming cross-dialect marker routing (Anthropic→OpenAI)"
+```
+
+---
+
+### Task 2: Add streaming cross-dialect routing
+
+**Files:**
+- Modify: `crates/lunaroute-ingress/src/anthropic.rs` (replace the `todo!()` from Task 1)
+- Test: `crates/lunaroute-ingress/src/anthropic.rs` (inline tests module)
+
+- [ ] **Step 1: Write failing test for streaming conversion**
+
+Add a test in the `mod tests` block that verifies `NormalizedStreamEvent` events convert to Anthropic SSE events correctly (this exercises `stream_event_to_anthropic_events`):
+
+```rust
+#[test]
+fn test_cross_dialect_stream_event_conversion() {
+    use lunaroute_core::normalized::Delta;
+
+    // Simulate what the streaming cross-dialect path does:
+    // NormalizedStreamEvent (from OpenAI connector) → Anthropic SSE events
+
+    let mut content_block_started = false;
+
+    // Test a text delta event (struct variant with index + delta fields)
+    let event = NormalizedStreamEvent::Delta {
+        index: 0,
+        delta: Delta {
+            role: None,
+            content: Some("Hello from Kimi".to_string()),
+        },
+    };
+
+    let anthropic_events = stream_event_to_anthropic_events(
+        event,
+        "msg_test123",
+        "@cf/moonshotai/kimi-k2.5",
+        &mut content_block_started,
+    );
+
+    // Should produce: ContentBlockStart + ContentBlockDelta
+    assert!(content_block_started);
+    assert!(anthropic_events.len() >= 2);
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+This exercises existing `stream_event_to_anthropic_events()` which already works.
+
+Run: `cargo test -p lunaroute-ingress -- test_cross_dialect_stream_event_conversion -v`
+Expected: PASS
+
+- [ ] **Step 3: Replace the `todo!()` with streaming cross-dialect implementation**
+
+In `crates/lunaroute-ingress/src/anthropic.rs`, find the `todo!("Streaming cross-dialect not yet implemented")` from Task 1 and replace the entire streaming branch:
+
+```rust
+if is_streaming {
+    let mut normalized = to_normalized(typed_req)?;
+    normalized.stream = true;
+
+    let event_stream = cd_connector.stream(normalized).await
+        .map_err(|e| IngressError::ProviderError(e.to_string()))?;
+
+    let stream_id = Arc::new(format!("msg_{}", uuid::Uuid::new_v4().simple()));
+    let model_arc = Arc::new(model.clone());
+
+    let sse_stream = event_stream
+        .scan(false, move |content_block_started, result| {
+            let stream_id = Arc::clone(&stream_id);
+            let model = Arc::clone(&model_arc);
+            let events = match result {
+                Ok(event) => stream_event_to_anthropic_events(
+                    event,
+                    stream_id.as_str(),
+                    model.as_str(),
+                    content_block_started,
+                ),
+                Err(e) => {
+                    tracing::error!("Cross-dialect stream error: {}", e);
+                    vec![]
+                }
+            };
+            futures::future::ready(Some(
+                futures::stream::iter(events.into_iter().map(Ok)),
+            ))
+        })
+        .flatten();
+
+    return Ok(Sse::new(sse_stream)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(std::time::Duration::from_secs(
+                    state.sse_keepalive_interval_secs,
+                ))
+                .text(""),
+        )
+        .into_response());
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo check -p lunaroute-ingress`
+Expected: Compiles cleanly, no `todo!()` warning
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cargo test -p lunaroute-ingress`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/lunaroute-ingress/src/anthropic.rs
+git commit -m "feat: add streaming cross-dialect marker routing (Anthropic→OpenAI)"
+```
+
+---
+
+### Task 3: Add model override to eran.yaml config
+
+**Files:**
+- Modify: `examples/configs/private/eran.yaml` (kimik25 section)
+
+- [ ] **Step 1: Add model override to kimik25 provider config**
+
+In `examples/configs/private/eran.yaml`, add the `model` field to the kimik25 provider (after the `base_url` line):
+
+```yaml
+  kimik25:
+    provider_type: "openai"
+    enabled: true
+    api_key: "${CLOUDFLARE_API_KEY}"
+    base_url: "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1"
+    model: "@cf/moonshotai/kimi-k2.5"
+```
+
+- [ ] **Step 2: Verify full project builds**
+
+Run: `cargo build`
+Expected: Successful build
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/configs/private/eran.yaml
+git commit -m "config: add model override for kimik25 Cloudflare provider"
+```
+
+---
+
+### Task 4: Add tool use round-trip test
+
+**Files:**
+- Test: `crates/lunaroute-ingress/src/anthropic.rs` (inline tests module)
+
+- [ ] **Step 1: Write test for tool use normalization round-trip**
+
+```rust
+#[test]
+fn test_cross_dialect_tool_use_roundtrip() {
+    // Anthropic tool_use → normalized → back to Anthropic
+    let raw_json = serde_json::json!({
+        "model": "@cf/moonshotai/kimi-k2.5",
+        "messages": [
+            {"role": "user", "content": "What's the weather?"}
+        ],
+        "max_tokens": 1024,
+        "stream": false,
+        "tools": [{
+            "name": "get_weather",
+            "description": "Get weather for a location",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"}
+                },
+                "required": ["location"]
+            }
+        }]
+    });
+
+    let typed_req: AnthropicMessagesRequest = serde_json::from_value(raw_json).unwrap();
+    let normalized = to_normalized(typed_req).unwrap();
+
+    // Verify tool was normalized
+    assert_eq!(normalized.tools.len(), 1);
+    assert_eq!(normalized.tools[0].function.name, "get_weather");
+
+    // Simulate provider response with tool call
+    let normalized_resp = NormalizedResponse {
+        id: "chatcmpl-test".to_string(),
+        model: "@cf/moonshotai/kimi-k2.5".to_string(),
+        choices: vec![Choice {
+            index: 0,
+            message: Message {
+                role: Role::Assistant,
+                content: MessageContent::Text(String::new()),
+                name: None,
+                tool_calls: vec![ToolCall {
+                    id: "call_abc123".to_string(),
+                    tool_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: "get_weather".to_string(),
+                        arguments: r#"{"location":"San Francisco"}"#.to_string(),
+                    },
+                }],
+                tool_call_id: None,
+            },
+            finish_reason: Some(FinishReason::ToolCalls),
+        }],
+        usage: Usage {
+            prompt_tokens: 20,
+            completion_tokens: 10,
+            total_tokens: 30,
+        },
+        created: 1234567890,
+        metadata: std::collections::HashMap::new(),
+    };
+
+    let anthropic_resp = from_normalized(normalized_resp);
+    assert_eq!(anthropic_resp.stop_reason, Some("tool_use".to_string()));
+
+    // Find the tool_use block in content
+    let tool_use = anthropic_resp.content.iter().find(|c| {
+        matches!(c, AnthropicContent::ToolUse { .. })
+    });
+    assert!(tool_use.is_some(), "Expected tool_use block in response");
+
+    if let Some(AnthropicContent::ToolUse { id, name, input }) = tool_use {
+        assert_eq!(id, "call_abc123");
+        assert_eq!(name, "get_weather");
+        assert_eq!(input["location"], "San Francisco");
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cargo test -p lunaroute-ingress -- test_cross_dialect_tool_use_roundtrip -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lunaroute-ingress/src/anthropic.rs
+git commit -m "test: add cross-dialect tool use round-trip test"
+```
+
+---
+
+### Task 5: Regression — verify existing tests pass
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cargo test`
+Expected: All tests pass
+
+- [ ] **Step 2: Verify build in release mode**
+
+Run: `cargo build --release`
+Expected: Clean build

--- a/docs/superpowers/specs/2026-04-03-cross-dialect-marker-routing-design.md
+++ b/docs/superpowers/specs/2026-04-03-cross-dialect-marker-routing-design.md
@@ -1,0 +1,216 @@
+# Cross-Dialect Marker Routing
+
+**Date:** 2026-04-03
+**Status:** Draft
+**Extends:** [LUNAROUTE Marker-Based Provider Routing](2026-04-03-lunaroute-marker-routing-design.md)
+
+## Problem
+
+LUNAROUTE marker routing currently rejects cross-dialect requests — e.g., an Anthropic-format request (from Claude Code) targeting an OpenAI-type provider (like Kimi K2.5 on Cloudflare). The original spec explicitly scoped this out. Now it's needed.
+
+## Solution
+
+When `messages_passthrough()` detects a marker targeting a provider whose dialect doesn't match the request format, instead of returning an error, translate the request through the existing normalization pipeline and use the target provider's `Provider` trait implementation.
+
+All conversion pieces already exist. No new modules or egress changes needed.
+
+## Scope
+
+**In scope:** Anthropic-format request → OpenAI-type provider (the immediate need).
+
+**Future work:** OpenAI-format request → Anthropic-type provider (symmetric case in `chat_completions_passthrough()`). Same pattern but not needed yet.
+
+## Data Flow
+
+```
+Claude Code (Anthropic format, /v1/messages)
+  → messages_passthrough()
+    → extract session_id from metadata (raw JSON, before parse)
+    → extract LUNAROUTE marker → provider name
+    → detect connector_type == OpenAI (cross-dialect)
+    → strip marker from request
+    → apply model_override to raw JSON
+    → [session recording: provider = marker provider name, listener = "anthropic"]
+    → parse raw JSON → AnthropicMessagesRequest (serde_json::from_value)
+    → to_normalized() → NormalizedRequest
+    → force NormalizedRequest.stream to match chosen path
+    → openai_connector.send() or .stream() via Provider trait
+    → NormalizedResponse / NormalizedStreamEvent stream
+    → from_normalized() or stream_event_to_anthropic_events()
+  → Client (Anthropic format response)
+```
+
+## Design Decisions
+
+**Authentication:** The cross-dialect path uses the target provider's configured auth (e.g., `CLOUDFLARE_API_KEY` from the registry), not client-provided headers. The client authenticates to LunaRoute; LunaRoute authenticates to the upstream provider. Client headers like `x-api-key` and `Authorization` are not forwarded in cross-dialect mode. This is intentional — the client's Anthropic API key is meaningless to Cloudflare.
+
+**Metadata preservation:** The `AnthropicMessagesRequest` struct does not have a `metadata` field, so client metadata is dropped during typed parsing. This is acceptable because: (a) session_id extraction from `metadata.user_id` happens from raw JSON *before* the cross-dialect branch, so session recording works; (b) the target OpenAI provider doesn't understand Anthropic metadata anyway.
+
+**HTTP status codes:** Successful cross-dialect responses always return HTTP 200 (since `Provider::send()` returns a typed `NormalizedResponse`, not raw status codes). Upstream 4xx/5xx errors are caught by `Provider::send()`/`stream()` and surface as `IngressError::ProviderError`. This differs from same-dialect passthrough which forwards the upstream status code directly.
+
+**Feature coverage:** The normalization pipeline handles text messages, tool_use, and tool_result. Advanced Anthropic features (extended thinking, cache control hints, images) may not round-trip cleanly. This is acceptable for the initial use case (routing to Kimi K2.5 which only supports text/tools).
+
+**`stream` field consistency:** Before calling `Provider::send()`, force `normalized.stream = false`. Before calling `Provider::stream()`, force `normalized.stream = true`. This prevents mismatches between the chosen code path and the request body sent to the upstream.
+
+## Changes
+
+### 1. `crates/lunaroute-ingress/src/anthropic.rs` — `messages_passthrough()`
+
+**Modified function structure (pseudocode):**
+
+```
+messages_passthrough():
+  extract marker
+  match marker:
+    Provider(name) =>
+      lookup in registry
+      if entry.connector_type == Anthropic:
+        // same-dialect: existing logic (set override_connector)
+      else if entry.connector_type == OpenAI:
+        // cross-dialect: store openai_connector + set flag
+        cross_dialect_connector = entry.openai_connector
+        marker_provider_name = name
+        apply model_override to raw JSON
+      strip marker
+    Clear => strip marker
+    None => pass
+
+  // Session ID extraction (unchanged, from raw JSON)
+  // Header collection (unchanged, but only used for same-dialect path)
+
+  extract model, is_streaming from raw JSON
+
+  // Session recording (shared between paths)
+  // provider field = marker_provider_name.unwrap_or("anthropic")
+  // listener field = "anthropic" (always, since request arrived on /v1/messages)
+
+  if cross_dialect_connector.is_some():
+    // === CROSS-DIALECT PATH (returns early) ===
+    parse req -> AnthropicMessagesRequest
+    to_normalized() -> NormalizedRequest
+
+    if is_streaming:
+      normalized.stream = true
+      connector.stream(normalized) -> NormalizedStreamEvent stream
+      convert via stream_event_to_anthropic_events() -> Anthropic SSE
+      return SSE response
+    else:
+      normalized.stream = false
+      connector.send(normalized) -> NormalizedResponse
+      from_normalized() -> AnthropicResponse
+      return JSON response
+
+  // === SAME-DIALECT PATH (existing code, unchanged) ===
+  existing passthrough logic...
+```
+
+**Current code being replaced (lines 895-904):**
+```rust
+if entry.connector_type != crate::ProviderType::Anthropic {
+    return Err(IngressError::InvalidRequest(format!(
+        "LUNAROUTE marker targets provider '{}' ({:?}) but request uses Anthropic format. Cross-dialect routing requires normalized mode.",
+        name, entry.connector_type
+    )));
+}
+```
+
+**Non-streaming cross-dialect path:**
+```rust
+let typed_req: AnthropicMessagesRequest = serde_json::from_value(req.clone())
+    .map_err(|e| IngressError::InvalidRequest(
+        format!("Failed to parse request for cross-dialect routing: {}", e)
+    ))?;
+
+let mut normalized = to_normalized(typed_req)?;
+normalized.stream = false;
+
+let normalized_resp = cross_dialect_connector.send(normalized).await
+    .map_err(|e| IngressError::ProviderError(e.to_string()))?;
+
+let anthropic_resp = from_normalized(normalized_resp);
+return Ok(Json(anthropic_resp).into_response());
+```
+
+**Streaming cross-dialect path:**
+```rust
+let typed_req: AnthropicMessagesRequest = serde_json::from_value(req.clone())
+    .map_err(|e| IngressError::InvalidRequest(
+        format!("Failed to parse request for cross-dialect routing: {}", e)
+    ))?;
+
+let mut normalized = to_normalized(typed_req)?;
+normalized.stream = true;
+
+let event_stream = cross_dialect_connector.stream(normalized).await
+    .map_err(|e| IngressError::ProviderError(e.to_string()))?;
+
+// model here is the already-overridden model from raw JSON extraction
+let stream_id = Arc::new(format!("msg_{}", uuid::Uuid::new_v4().simple()));
+let model_arc = Arc::new(model.clone());
+
+let sse_stream = event_stream
+    .scan(false, move |content_block_started, result| {
+        let stream_id = Arc::clone(&stream_id);
+        let model = Arc::clone(&model_arc);
+        let events = match result {
+            Ok(event) => stream_event_to_anthropic_events(
+                event, stream_id.as_str(), model.as_str(), content_block_started,
+            ),
+            Err(e) => {
+                tracing::error!("Cross-dialect stream error: {}", e);
+                vec![]
+            }
+        };
+        futures::future::ready(Some(futures::stream::iter(events.into_iter().map(Ok))))
+    })
+    .flatten();
+
+return Ok(Sse::new(sse_stream).into_response());
+```
+
+**Session recording:** The session recording code block (lines 1064-1227) runs before the cross-dialect branch. The `provider` field in `SessionEvent::Started` should use the marker provider name when present:
+
+```rust
+provider: marker_provider_name.clone().unwrap_or_else(|| "anthropic".to_string()),
+listener: "anthropic".to_string(),
+```
+
+**Error handling:** When `Provider::send()` or `Provider::stream()` returns an error (upstream 4xx/5xx), it surfaces as `IngressError::ProviderError`. The existing `IngressError` → HTTP response conversion in the error handler produces a JSON error response. This is sufficient for v1 — the client gets an error with context about what went wrong. Translating upstream error codes (429, 500) into Anthropic-format `{"type": "error", "error": {...}}` is a future improvement.
+
+### 2. Config: `eran.yaml` — add model override
+
+```yaml
+kimik25:
+    provider_type: "openai"
+    enabled: true
+    api_key: "${CLOUDFLARE_API_KEY}"
+    base_url: "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1"
+    model: "@cf/moonshotai/kimi-k2.5"
+```
+
+The `model` field becomes the `model_override` in the registry entry. Without it, the client's model name (e.g., `claude-sonnet-4-20250514`) would be sent to Cloudflare, which wouldn't recognize it.
+
+## What Stays the Same
+
+- Default passthrough behavior (Anthropic→Anthropic, OpenAI→OpenAI) — zero cost, untouched
+- Provider registry structure — no changes
+- Egress modules — no changes (Provider trait methods already public)
+- Normalized mode handlers — untouched
+- Config parsing — `model` field already maps to `model_override` in the registry
+
+## Performance
+
+- Cross-dialect marker requests: ~1ms normalization overhead (parse + convert + serialize)
+- Normal same-dialect requests: zero additional cost (existing passthrough path unchanged)
+- Normalization is per-request, not per-chunk. Streaming chunks flow through the Provider trait's stream implementation which already handles SSE parsing efficiently.
+
+## Testing
+
+1. **Round-trip:** Anthropic JSON → normalize → OpenAI JSON preserves message content, tools, system prompt
+2. **Integration (non-streaming):** Anthropic-format request with LUNAROUTE marker targeting OpenAI provider → response in Anthropic format
+3. **Integration (streaming):** Same with `"stream": true` → valid Anthropic SSE events
+4. **Model override:** Verify the model sent to upstream is `model_override`, not client's original model
+5. **Error path:** Provider returns error → client gets sensible error response
+6. **Tool use round-trip:** Anthropic tool_use/tool_result → normalized → OpenAI function_call/tool_calls and back
+7. **Session recording:** Events record correct provider name ("kimik25") and listener ("anthropic")
+8. **Regression:** Existing same-dialect passthrough tests still pass

--- a/examples/configs/private/eran.yaml
+++ b/examples/configs/private/eran.yaml
@@ -1,0 +1,197 @@
+# Dual-Dialect Passthrough Configuration
+#
+# This configuration enables BOTH OpenAI and Anthropic API formats simultaneously
+# in a single server instance using the "both" dialect mode.
+#
+# DUAL-DIALECT MODE:
+# - api_dialect: "both" → accepts BOTH formats:
+#   * OpenAI format at /v1/chat/completions
+#   * Anthropic format at /v1/messages
+# - Routes determined by model prefix:
+#   * gpt-* models → OpenAI provider (passthrough, no normalization)
+#   * claude-* models → Anthropic provider (passthrough, no normalization)
+#
+# BENEFITS:
+# - Single server instance for both Claude Code and Codex
+# - Zero-copy passthrough for both formats (optimal performance)
+# - 100% API fidelity (preserves extended thinking, etc.)
+# - Sub-millisecond overhead for both dialects
+#
+# This is ideal for development environments or when you need a unified
+# gateway that supports both OpenAI and Anthropic clients simultaneously.
+
+# Server configuration
+host: "127.0.0.1"
+port: 8081
+
+# HTTP server settings (optional - controls server-side HTTP/TCP behavior)
+# Uncomment to customize from defaults
+# http_server:
+#   # TCP settings - disable Nagle's algorithm for low-latency streaming
+#   tcp_nodelay: true              # Default: true - Essential for SSE performance
+#   tcp_keepalive_secs: 60         # Default: 60 - Detect dead connections
+#
+#   # SSE streaming settings - keep connections alive during long operations
+#   sse_keepalive_enabled: true    # Default: true - Send keepalive comments
+#   sse_keepalive_interval_secs: 15 # Default: 15 - Interval between keepalives
+#                                   # Lower values (10-15s) recommended for proxies
+#
+#   # Buffer settings (null = use OS defaults)
+#   send_buffer_size: null         # TCP send buffer in bytes
+#   recv_buffer_size: null         # TCP receive buffer in bytes
+
+# API dialect - determines which format(s) the server accepts
+# openai = accepts POST /v1/chat/completions (OpenAI format only)
+# anthropic = accepts POST /v1/messages (Anthropic format only)
+# both = accepts BOTH formats simultaneously
+api_dialect: both
+
+# Logging
+logging:
+  level: "info"
+  log_requests: true
+
+# Provider definitions
+# Both providers configured, enabling routing to either OpenAI or Anthropic backends
+providers:
+  # OpenAI provider - passthrough for gpt-* models
+  openai:
+    enabled: true
+    # No api_key field = passthrough mode - will use:
+    #   1. OPENAI_API_KEY environment variable, OR
+    #   2. Client's Authorization header (Codex provides this)
+    # Use ChatGPT backend API for Codex compatibility
+    base_url: "https://chatgpt.com/backend-api/codex"
+    codex_auth:
+      enabled: true  # Required for ChatGPT Codex backend
+
+  # Anthropic provider - passthrough for claude-* models
+  anthropic:
+    enabled: true
+    # No api_key field = passthrough mode - will use:
+    #   1. ANTHROPIC_API_KEY environment variable, OR
+    #   2. Client's x-api-key header (Claude Code provides this)
+    # No base_url specified = uses default https://api.anthropic.com
+
+  # Kimi K2.5 via Cloudflare AI Gateway - no automatic routing, manual testing only
+  kimik25:
+    provider_type: "openai"
+    enabled: true
+    api_key: "${CLOUDFLARE_API_KEY}"
+    base_url: "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1"
+    model: "@cf/moonshotai/kimi-k2.5"
+
+    # Optional: HTTP client configuration for connection pooling
+    # Uncomment to customize timeouts (uses sensible defaults if not specified)
+    # http_client:
+    #   # Request timeout - how long to wait for entire request (including streaming)
+    #   timeout_secs: 600              # Default: 600s (10 min)
+    #
+    #   # Connection timeout - how long to wait when establishing connection
+    #   connect_timeout_secs: 10       # Default: 10s
+    #
+    #   # Pool idle timeout - how long idle connections stay in pool
+    #   # Increase this if you see "poor internet connection" errors after 5-10 minutes
+    #   pool_idle_timeout_secs: 600    # Default: 600s (10 min), was 50s before v0.1.4
+    #
+    #   # TCP keepalive - send keepalive packets during long requests
+    #   tcp_keepalive_secs: 60         # Default: 60s
+    #
+    #   # Max retries for transient errors
+    #   max_retries: 3                 # Default: 3
+
+# Routing configuration
+# NOTE: Routing rules are automatically generated based on providers and model patterns.
+# The code will create rules that route:
+# - gpt-* models → OpenAI provider
+# - claude-* models → Anthropic provider
+# No explicit routing configuration needed in passthrough mode.
+
+# Session recording (required for analytics dashboard)
+session_recording:
+  enabled: true
+
+  # SQLite backend - stores session metadata and stats
+  sqlite:
+    enabled: true
+    path: "~/.lunaroute/sessions.db"
+    max_connections: 10
+
+  # JSONL backend - full request/response recording
+  jsonl:
+    enabled: true
+    directory: "~/.lunaroute/sessions"
+    retention:
+      max_age_days: 30        # Delete sessions older than 30 days
+      max_size_mb: 1024       # Delete oldest when total size exceeds 1GB
+
+# Analytics Dashboard / UI Server
+ui:
+  enabled: true
+  host: "127.0.0.1"
+  port: 8082
+  refresh_interval: 5  # Auto-refresh interval in seconds
+
+# Example usage:
+#
+# 1. Set environment variables:
+#    export OPENAI_API_KEY="sk-..."
+#    export ANTHROPIC_API_KEY="sk-ant-..."
+#
+# 2. Start the server:
+#    lunaroute-server --config examples/configs/dual-dialect-passthrough.yaml
+#
+# 3. Access the analytics dashboard:
+#    Open http://localhost:8082 in your browser
+#    - View real-time request metrics and session statistics
+#    - Monitor provider performance and routing decisions
+#    - Export session data for analysis
+#
+# 4. Test with Claude Code (Anthropic format):
+#    export ANTHROPIC_BASE_URL=http://localhost:8081
+#    # Claude Code will send requests to /v1/messages
+#    # Routed to Anthropic provider (passthrough, no normalization)
+#
+# 5. Test with Codex (OpenAI Responses API):
+#    # NOTE: Codex v0.47.0 has known issues with OPENAI_BASE_URL environment variable.
+#    # You may need to configure Codex via config.toml instead. See openai-proxy-with-recording.yaml
+#    # for an example of Codex configuration.
+#    export OPENAI_BASE_URL=http://localhost:8081
+#    codex exec "what is 2+2"
+#    # Sends requests to /responses (Responses API)
+#    # Routed to OpenAI provider (passthrough, no normalization)
+#
+# 6. Test Claude model with Anthropic format (passthrough):
+#    curl http://localhost:8081/v1/messages \
+#      -H "Content-Type: application/json" \
+#      -H "x-api-key: $ANTHROPIC_API_KEY" \
+#      -H "anthropic-version: 2023-06-01" \
+#      -d '{
+#        "model": "claude-3-5-sonnet-20241022",
+#        "messages": [{"role": "user", "content": "Hello"}],
+#        "max_tokens": 100
+#      }'
+#    # Direct passthrough to Anthropic (no normalization)
+#
+# 7. Test GPT model with OpenAI format (passthrough):
+#    curl http://localhost:8081/v1/chat/completions \
+#      -H "Content-Type: application/json" \
+#      -H "Authorization: Bearer $OPENAI_API_KEY" \
+#      -d '{
+#        "model": "gpt-4",
+#        "messages": [{"role": "user", "content": "Hello"}]
+#      }'
+#    # Direct passthrough to OpenAI (no normalization)
+#
+# ROUTING BEHAVIOR:
+# - OpenAI format at /v1/chat/completions:
+#   * gpt-* models → OpenAI provider (passthrough)
+#   * claude-* models → Anthropic provider (WITH normalization OpenAI→Anthropic→OpenAI)
+#
+# - Anthropic format at /v1/messages:
+#   * claude-* models → Anthropic provider (passthrough)
+#   * gpt-* models → OpenAI provider (WITH normalization Anthropic→OpenAI→Anthropic)
+#
+# For OPTIMAL performance (zero normalization overhead):
+# - Use Claude models with Anthropic format (/v1/messages)
+# - Use GPT models with OpenAI format (/v1/chat/completions)


### PR DESCRIPTION
## Summary

- Adds cross-dialect routing: Anthropic-format requests can now be routed to OpenAI-type providers via LUNAROUTE markers (e.g., Claude Code → Kimi K2.5 on Cloudflare)
- Supports both streaming (SSE with synthetic `message_start`) and non-streaming paths
- Normal same-dialect passthrough is unchanged — zero additional cost

## How it works

When `messages_passthrough()` detects a marker targeting an OpenAI-type provider:
1. Parse raw Anthropic JSON → `AnthropicMessagesRequest`
2. Normalize via `to_normalized()` → `NormalizedRequest`
3. Send through `OpenAIConnector.send()`/`.stream()` via the `Provider` trait
4. Convert response back via `from_normalized()` / `stream_event_to_anthropic_events()`

## Test plan

- [x] Round-trip test: Anthropic JSON → normalize → Anthropic JSON preserves content
- [x] Tool use round-trip: tool_use/tool_result survives normalization
- [x] Stream event conversion: NormalizedStreamEvent → Anthropic SSE events
- [x] Error SSE event serialization
- [x] Model override ordering verification
- [x] Full test suite passes (132 unit + 19 integration)
- [x] Release build clean
- [x] Roborev review: no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)