### PR TITLE
feat: Codex CLI WebSocket support for /responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ temp/
 
 # private configs
 examples/configs/private/
+
+# Git worktrees
+.worktrees/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.6", features = ["full"] }
 reqwest = { version = "0.13", features = ["json", "stream", "rustls"], default-features = false }
 eventsource-stream = "0.2"
+tokio-tungstenite = "0.28"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ See `examples/configs/provider-switch-notification.yaml` for complete example.
 ### Supported AI Assistants
 
 - ✅ **Claude Code** - Full passthrough support, zero config
-- ✅ **OpenAI Codex CLI** - Automatic auth.json integration
+- ✅ **OpenAI Codex CLI** - Automatic auth.json integration. Supports both HTTP and WebSocket transports — set `supports_websockets = true` in `~/.codex/config.toml` to use the WS path (lunaroute terminates the WS and drives the HTTP pipeline; session recording, markers, and metrics all work the same).
 - ✅ **OpenCode** - Standard OpenAI/Anthropic API compatibility
 - ✅ **Custom Clients** - Any tool using OpenAI or Anthropic APIs
 

--- a/crates/lunaroute-ingress/src/lib.rs
+++ b/crates/lunaroute-ingress/src/lib.rs
@@ -21,6 +21,7 @@ pub mod types;
 pub use bypass::{BypassError, BypassProvider, proxy_request, with_bypass};
 pub use middleware::CorsConfig;
 pub use provider_registry::{ProviderEntry, ProviderRegistry, ProviderType};
+pub use responses_ws::responses_ws_handler;
 pub use types::{
     IngressError, IngressResult, RequestId, RequestMetadata, StreamEvent, TraceContext,
 };

--- a/crates/lunaroute-ingress/src/lib.rs
+++ b/crates/lunaroute-ingress/src/lib.rs
@@ -14,6 +14,7 @@ pub mod middleware;
 pub mod multi_dialect;
 pub mod openai;
 pub mod provider_registry;
+pub mod responses_ws;
 pub mod streaming_metrics;
 pub mod types;
 

--- a/crates/lunaroute-ingress/src/openai.rs
+++ b/crates/lunaroute-ingress/src/openai.rs
@@ -32,6 +32,17 @@ const MAX_TOOL_ARGS_SIZE: usize = 1_000_000;
 /// Maximum number of SSE events to collect for async parsing (prevents OOM on very long streams)
 const MAX_COLLECTED_EVENTS: usize = 10_000;
 
+/// A single SSE event yielded by the shared responses pipeline.
+///
+/// Both the HTTP handler (which re-wraps in `axum::response::sse::Event`)
+/// and the WebSocket handler (which sends the `data` payload as a text frame)
+/// consume this.
+#[derive(Debug, Clone)]
+pub(crate) struct SseEvent {
+    pub event: String,
+    pub data: String,
+}
+
 /// Detect if a tool result content indicates an error using keyword heuristics.
 /// OpenAI doesn't have an explicit is_error field, so we use pattern matching.
 fn detect_tool_error(content: &str) -> bool {
@@ -899,6 +910,619 @@ struct ModelObject {
     owned_by: String,
 }
 
+/// Drive the upstream `/responses` streaming pipeline and return a stream of
+/// SSE events. Shared by HTTP `responses_passthrough` and the WebSocket
+/// handler in `crate::responses_ws`.
+///
+/// Performs: header filtering, LUNAROUTE marker detection, session recording
+/// (Started / RequestRecorded / StatsUpdated / ToolCallRecorded / Completed),
+/// upstream call via `OpenAIConnector::stream_passthrough_to_endpoint_bytes`,
+/// SSE parsing, and metric extraction. Identical side effects to the original
+/// streaming branch — just no axum wrapping.
+pub(crate) async fn responses_sse_stream(
+    state: Arc<OpenAIPassthroughState>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> Result<futures::stream::BoxStream<'static, Result<SseEvent, IngressError>>, IngressError> {
+    let start_time = std::time::Instant::now();
+
+    // Extract user-agent from headers for session tracking
+    let user_agent = headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| {
+            if s.len() > 255 {
+                s.chars().take(255).collect()
+            } else {
+                s.to_string()
+            }
+        });
+
+    // Pass through only standard OpenAI API headers
+    let mut passthrough_headers = std::collections::HashMap::new();
+    let allowed_headers = [
+        "authorization",
+        "content-type",
+        "accept",
+        "user-agent",
+        "openai-beta",
+        "openai-organization",
+        "x-request-id",
+    ];
+
+    // Extract session_id header for session grouping (before filtering)
+    let client_session_id = headers
+        .get("session_id")
+        .or_else(|| headers.get("session-id"))
+        .or_else(|| headers.get("x-session-id"))
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    for (name, value) in headers.iter() {
+        let name_str = name.as_str().to_lowercase();
+        if !allowed_headers.contains(&name_str.as_str()) {
+            continue;
+        }
+        if let Ok(value_str) = value.to_str() {
+            passthrough_headers.insert(name.as_str().to_lowercase(), value_str.to_string());
+        }
+    }
+
+    // Parse body to extract metadata for session recording
+    let (model, req_json) = if let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&body) {
+        let model = parsed
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        (model, Some(parsed))
+    } else {
+        ("unknown".to_string(), None)
+    };
+
+    let before_provider = std::time::Instant::now();
+    let pre_provider_overhead = before_provider.duration_since(start_time);
+
+    // Use client-provided session ID if available, otherwise generate new one
+    let recording_session_id = if state.session_store.is_some() {
+        Some(client_session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()))
+    } else {
+        None
+    };
+
+    let recording_request_id = if state.session_store.is_some() {
+        Some(uuid::Uuid::new_v4().to_string())
+    } else {
+        None
+    };
+
+    // Start session recording if enabled (using async events)
+    if let (Some(session_store), Some(session_id), Some(request_id), Some(req)) = (
+        &state.session_store,
+        &recording_session_id,
+        &recording_request_id,
+        &req_json,
+    ) {
+        use lunaroute_session::{SessionEvent, events::SessionMetadata as V2Metadata};
+
+        // Write Started event asynchronously (spawn task for zero latency)
+        let store = session_store.clone();
+        let sid = session_id.clone();
+        let rid = request_id.clone();
+        let m = model.clone();
+        let ua = user_agent.clone();
+        tokio::spawn(async move {
+            let event = serde_json::to_value(SessionEvent::Started {
+                session_id: sid,
+                request_id: rid,
+                timestamp: chrono::Utc::now(),
+                model_requested: m,
+                provider: "openai".to_string(),
+                listener: "openai".to_string(),
+                is_streaming: true,
+                metadata: V2Metadata {
+                    client_ip: None,
+                    user_agent: ua,
+                    api_version: None,
+                    request_headers: Default::default(),
+                    session_tags: vec![],
+                },
+            })
+            .ok();
+            if let Some(ev) = event {
+                let _ = store.write_event(None, ev).await;
+            }
+        });
+
+        // Record RequestRecorded event asynchronously
+        use lunaroute_session::events::RequestStats;
+
+        // Extract request text from messages or prompt (best effort)
+        let request_text = req
+            .get("messages")
+            .and_then(|m| m.as_array())
+            .and_then(|msgs| msgs.last())
+            .and_then(|msg| msg.get("content"))
+            .and_then(|c| c.as_str())
+            .or_else(|| req.get("prompt").and_then(|p| p.as_str()))
+            .unwrap_or("")
+            .to_string();
+
+        let message_count = req
+            .get("messages")
+            .and_then(|m| m.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+
+        let has_system_prompt = req
+            .get("messages")
+            .and_then(|m| m.as_array())
+            .and_then(|msgs| msgs.first())
+            .and_then(|msg| msg.get("role").and_then(|r| r.as_str()))
+            .map(|role| role == "system")
+            .unwrap_or(false);
+
+        let has_tools = req.get("tools").is_some();
+        let tool_count = req
+            .get("tools")
+            .and_then(|t| t.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+
+        let store_clone = session_store.clone();
+        let session_id_clone = session_id.clone();
+        let request_id_clone = request_id.clone();
+        let req_size = body.len();
+        let req_clone = req.clone();
+        let tool_call_mapper_clone = state.tool_call_mapper.clone();
+        tokio::spawn(async move {
+            let event = SessionEvent::RequestRecorded {
+                session_id: session_id_clone.clone(),
+                request_id: request_id_clone.clone(),
+                timestamp: chrono::Utc::now(),
+                request_text,
+                request_json: req_clone.clone(),
+                estimated_tokens: 0,
+                stats: RequestStats {
+                    pre_processing_ms: pre_provider_overhead.as_secs_f64() * 1000.0,
+                    request_size_bytes: req_size,
+                    message_count,
+                    has_system_prompt,
+                    has_tools,
+                    tool_count,
+                },
+            };
+            if let Ok(json) = serde_json::to_value(event) {
+                let _ = store_clone.write_event(None, json).await;
+            }
+
+            // Extract and record tool results from request body
+            let input_array = req_clone.get("input").or_else(|| req_clone.get("messages"));
+
+            if let Some(messages) = input_array.and_then(|m| m.as_array()) {
+                for message in messages {
+                    let mut tool_call_id: Option<&str> = None;
+                    let mut output_content: Option<&str> = None;
+                    let mut exit_code: Option<i64> = None;
+
+                    if let Some(msg_type) = message.get("type").and_then(|t| t.as_str())
+                        && msg_type == "function_call_output"
+                    {
+                        tool_call_id = message.get("call_id").and_then(|id| id.as_str());
+                        output_content = message.get("output").and_then(|o| o.as_str());
+
+                        if let Some(output) = output_content
+                            && output.starts_with("Exit code: ")
+                            && let Some(code_str) = output
+                                .lines()
+                                .next()
+                                .and_then(|line| line.strip_prefix("Exit code: "))
+                        {
+                            exit_code = code_str.trim().parse::<i64>().ok();
+                        }
+                    }
+
+                    if tool_call_id.is_none()
+                        && let Some(role) = message.get("role").and_then(|r| r.as_str())
+                        && role == "tool"
+                    {
+                        tool_call_id = message.get("tool_call_id").and_then(|id| id.as_str());
+                        output_content = message.get("content").and_then(|c| c.as_str());
+                        exit_code = message.get("exit_code").and_then(|e| e.as_i64());
+                    }
+
+                    if let Some(call_id) = tool_call_id {
+                        let success = exit_code.map(|code| code == 0);
+
+                        let tool_name = tool_call_mapper_clone
+                            .lookup(call_id)
+                            .unwrap_or_else(|| "unknown".to_string());
+
+                        let output_size = output_content.map(|c| c.len()).unwrap_or(0);
+                        let tool_result_event = SessionEvent::ToolCallRecorded {
+                            session_id: session_id_clone.clone(),
+                            request_id: request_id_clone.clone(),
+                            timestamp: chrono::Utc::now(),
+                            tool_name,
+                            tool_call_id: call_id.to_string(),
+                            execution_time_ms: None,
+                            input_size_bytes: 0,
+                            output_size_bytes: Some(output_size),
+                            success,
+                            tool_arguments: None,
+                        };
+
+                        if let Ok(json) = serde_json::to_value(tool_result_event) {
+                            let _ = store_clone.write_event(None, json).await;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // Handle streaming passthrough for responses endpoint - pass raw bytes
+    let stream_response = match state
+        .connector
+        .stream_passthrough_to_endpoint_bytes("responses", body, passthrough_headers)
+        .await
+    {
+        Ok(response) => response,
+        Err(e) => {
+            // Record error in session if recording is enabled
+            if let (Some(session_store), Some(session_id), Some(request_id)) = (
+                &state.session_store,
+                &recording_session_id,
+                &recording_request_id,
+            ) {
+                use lunaroute_session::{SessionEvent, events::FinalSessionStats};
+
+                // Record error asynchronously
+                let store_clone = session_store.clone();
+                let session_id_clone = session_id.clone();
+                let request_id_clone = request_id.clone();
+                let error_msg = e.to_string();
+                let start_clone = start_time;
+                tokio::spawn(async move {
+                    let duration = start_clone.elapsed();
+                    let event = SessionEvent::Completed {
+                        session_id: session_id_clone.clone(),
+                        request_id: request_id_clone,
+                        timestamp: chrono::Utc::now(),
+                        success: false,
+                        error: Some(error_msg),
+                        finish_reason: Some("error".to_string()),
+                        final_stats: Box::new(FinalSessionStats {
+                            total_duration_ms: duration.as_millis() as u64,
+                            provider_time_ms: 0,
+                            proxy_overhead_ms: duration.as_millis() as f64,
+                            total_tokens: Default::default(),
+                            tool_summary: Default::default(),
+                            performance: Default::default(),
+                            streaming_stats: None,
+                            estimated_cost: None,
+                        }),
+                    };
+                    if let Ok(json) = serde_json::to_value(event) {
+                        let _ = store_clone.write_event(None, json).await;
+                    }
+                });
+            }
+
+            // Handle provider errors by returning proper status codes
+            use lunaroute_egress::EgressError;
+            return match e {
+                EgressError::ProviderError {
+                    status_code,
+                    message,
+                } => {
+                    tracing::debug!("Provider returned error: {} - {}", status_code, message);
+                    Err(IngressError::ProviderErrorResponse {
+                        status: status_code,
+                        message,
+                    })
+                }
+                _ => Err(IngressError::ProviderError(e.to_string())),
+            };
+        }
+    };
+
+    use futures::StreamExt;
+    let byte_stream = stream_response.bytes_stream();
+    let sse_stream = eventsource_stream::EventStream::new(byte_stream);
+
+    // Track token data and model from streaming events
+    use std::sync::{Arc as StdArc, Mutex};
+
+    #[derive(Default, Clone)]
+    struct StreamingStats {
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        total_tokens: u64,
+        model_used: Option<String>,
+        finish_reason: Option<String>,
+        response_size_bytes: usize,
+        stats_emitted: bool,
+        // Tool call tracking for Responses API
+        tool_calls: std::collections::HashMap<String, (String, String)>, // id -> (name, arguments)
+    }
+
+    let stats = StdArc::new(Mutex::new(StreamingStats {
+        model_used: Some(model.clone()),
+        ..Default::default()
+    }));
+    let stats_clone = stats.clone();
+
+    // Clone session recording info for use in stream
+    let session_store_clone = state.session_store.clone();
+    let session_id_clone = recording_session_id.clone();
+    let request_id_clone = recording_request_id.clone();
+    let start_time_clone = start_time;
+    let user_agent_clone = user_agent.clone();
+    let tool_call_mapper_clone = state.tool_call_mapper.clone();
+
+    let mapped_stream = sse_stream.filter_map(move |result| {
+        // Clone Arc-wrapped values before async move
+        let stats_for_async = stats_clone.clone();
+        let session_store_for_async = session_store_clone.clone();
+        let session_id_for_async = session_id_clone.clone();
+        let request_id_for_async = request_id_clone.clone();
+        let user_agent_for_async = user_agent_clone.clone();
+        let start_time_for_async = start_time_clone;
+        let tool_call_mapper_for_async = tool_call_mapper_clone.clone();
+
+        async move {
+            match &result {
+                Ok(event) => {
+                    // Try to parse event data as JSON to extract usage stats
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&event.data) {
+                        // Debug log to see event type and structure
+                        if !event.event.is_empty() {
+                            tracing::debug!("SSE event type: {}", event.event);
+                        }
+                        if let Some(response_type) = json.get("type").and_then(|t| t.as_str()) {
+                            tracing::debug!("Response type: {}", response_type);
+                        }
+
+                        let mut stats_guard = stats_for_async.lock().unwrap();
+
+                        // Extract tool calls from Responses API events
+                        if let Some(response_type) = json.get("type").and_then(|t| t.as_str()) {
+                            match response_type {
+                                // When a function_call output item is added, extract call_id and name
+                                "response.output_item.added" => {
+                                    if let Some(item) = json.get("item")
+                                        && let Some("function_call") =
+                                            item.get("type").and_then(|t| t.as_str())
+                                        && let (Some(call_id), Some(name)) = (
+                                            item.get("call_id").and_then(|id| id.as_str()),
+                                            item.get("name").and_then(|n| n.as_str()),
+                                        )
+                                    {
+                                        // Initialize tool call entry with name
+                                        stats_guard.tool_calls.insert(
+                                            call_id.to_string(),
+                                            (name.to_string(), String::new()),
+                                        );
+                                    }
+                                }
+                                // Accumulate function call arguments
+                                "response.function_call_arguments.delta" => {
+                                    if let (Some(call_id), Some(arguments)) = (
+                                        json.get("call_id").and_then(|id| id.as_str()),
+                                        json.get("arguments").and_then(|a| a.as_str()),
+                                    ) && let Some(entry) =
+                                        stats_guard.tool_calls.get_mut(call_id)
+                                    {
+                                        entry.1.push_str(arguments);
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+
+                        // Extract usage data if present (check both top-level and nested in response)
+                        let usage = json
+                            .get("usage")
+                            .or_else(|| json.get("response").and_then(|r| r.get("usage")));
+
+                        if let Some(usage) = usage {
+                            tracing::debug!("Found usage data in SSE event: {:?}", usage);
+                            // Responses API uses "input_tokens" and "output_tokens"
+                            // Chat Completions API uses "prompt_tokens" and "completion_tokens"
+                            stats_guard.prompt_tokens = usage
+                                .get("input_tokens")
+                                .or_else(|| usage.get("prompt_tokens"))
+                                .and_then(|t| t.as_u64())
+                                .unwrap_or(0);
+                            stats_guard.completion_tokens = usage
+                                .get("output_tokens")
+                                .or_else(|| usage.get("completion_tokens"))
+                                .and_then(|t| t.as_u64())
+                                .unwrap_or(0);
+                            stats_guard.total_tokens = usage
+                                .get("total_tokens")
+                                .and_then(|t| t.as_u64())
+                                .unwrap_or(0);
+
+                            // Emit events when we receive usage data (only once)
+                            if !stats_guard.stats_emitted
+                                && (stats_guard.prompt_tokens > 0
+                                    || stats_guard.completion_tokens > 0)
+                            {
+                                stats_guard.stats_emitted = true;
+
+                                // Clone data for async task
+                                let session_store_task = session_store_for_async.clone();
+                                let session_id_task = session_id_for_async.clone();
+                                let request_id_task = request_id_for_async.clone();
+                                let start_time_task = start_time_for_async;
+                                let user_agent_task = user_agent_for_async.clone();
+                                let prompt_tokens = stats_guard.prompt_tokens;
+                                let completion_tokens = stats_guard.completion_tokens;
+                                let total_tokens = stats_guard.total_tokens;
+                                let model_used = stats_guard.model_used.clone();
+                                let finish_reason = stats_guard.finish_reason.clone();
+                                let response_size = stats_guard.response_size_bytes;
+                                let tool_calls = stats_guard.tool_calls.clone();
+                                let tool_call_mapper = tool_call_mapper_for_async.clone();
+
+                                // Emit events asynchronously
+                                if let (Some(store), Some(sid), Some(rid)) =
+                                    (session_store_task, session_id_task, request_id_task)
+                                {
+                                    tokio::spawn(async move {
+                                        use lunaroute_session::{
+                                            SessionEvent,
+                                            events::{FinalSessionStats, TokenTotals},
+                                        };
+
+                                        // Emit StatsUpdated event
+                                        let token_updates = Some(TokenTotals {
+                                            total_input: prompt_tokens,
+                                            total_output: completion_tokens,
+                                            total_thinking: 0,
+                                            total_reasoning: 0,
+                                            total_cached: 0,
+                                            total_cache_read: 0,
+                                            total_cache_creation: 0,
+                                            total_audio_input: 0,
+                                            total_audio_output: 0,
+                                            grand_total: total_tokens,
+                                            by_model: Default::default(),
+                                        });
+
+                                        let stats_event = SessionEvent::StatsUpdated {
+                                            session_id: sid.clone(),
+                                            request_id: rid.clone(),
+                                            timestamp: chrono::Utc::now(),
+                                            token_updates,
+                                            tool_call_updates: None,
+                                            model_used: model_used.clone(),
+                                            response_size_bytes: response_size,
+                                            content_blocks: 1,
+                                            has_refusal: false,
+                                            user_agent: user_agent_task.clone(),
+                                        };
+
+                                        if let Ok(json) = serde_json::to_value(stats_event) {
+                                            let _ = store.write_event(None, json).await;
+                                        }
+
+                                        // Record and emit tool calls
+                                        for (tool_call_id, (tool_name, tool_arguments)) in
+                                            tool_calls
+                                        {
+                                            // Record to mapper for later lookup
+                                            tool_call_mapper.record_call(
+                                                tool_call_id.clone(),
+                                                tool_name.clone(),
+                                            );
+
+                                            // Emit ToolCallRecorded event
+                                            let input_size = tool_arguments.len();
+                                            let tool_call_event = SessionEvent::ToolCallRecorded {
+                                                session_id: sid.clone(),
+                                                request_id: rid.clone(),
+                                                timestamp: chrono::Utc::now(),
+                                                tool_name,
+                                                tool_call_id,
+                                                execution_time_ms: None,
+                                                input_size_bytes: input_size,
+                                                output_size_bytes: None,
+                                                success: None,
+                                                tool_arguments: Some(tool_arguments),
+                                            };
+
+                                            if let Ok(json) = serde_json::to_value(tool_call_event)
+                                            {
+                                                let _ = store.write_event(None, json).await;
+                                            }
+                                        }
+
+                                        // Emit Completed event
+                                        let duration = start_time_task.elapsed();
+                                        let completed_event = SessionEvent::Completed {
+                                            session_id: sid,
+                                            request_id: rid,
+                                            timestamp: chrono::Utc::now(),
+                                            success: true,
+                                            error: None,
+                                            finish_reason,
+                                            final_stats: Box::new(FinalSessionStats {
+                                                total_duration_ms: duration.as_millis() as u64,
+                                                provider_time_ms: duration.as_millis() as u64,
+                                                proxy_overhead_ms: 0.0,
+                                                total_tokens: TokenTotals {
+                                                    total_input: prompt_tokens,
+                                                    total_output: completion_tokens,
+                                                    total_thinking: 0,
+                                                    total_reasoning: 0,
+                                                    total_cached: 0,
+                                                    total_cache_read: 0,
+                                                    total_cache_creation: 0,
+                                                    total_audio_input: 0,
+                                                    total_audio_output: 0,
+                                                    grand_total: total_tokens,
+                                                    by_model: Default::default(),
+                                                },
+                                                tool_summary: Default::default(),
+                                                performance: Default::default(),
+                                                streaming_stats: None,
+                                                estimated_cost: None,
+                                            }),
+                                        };
+
+                                        if let Ok(json) = serde_json::to_value(completed_event) {
+                                            let _ = store.write_event(None, json).await;
+                                        }
+                                    });
+                                }
+                            }
+                        }
+
+                        // Extract model if present
+                        if let Some(model) = json.get("model").and_then(|m| m.as_str()) {
+                            stats_guard.model_used = Some(model.to_string());
+                        }
+
+                        // Extract finish_reason if present
+                        if let Some(choices) = json.get("choices").and_then(|c| c.as_array())
+                            && let Some(choice) = choices.first()
+                            && let Some(finish_reason) =
+                                choice.get("finish_reason").and_then(|fr| fr.as_str())
+                            && finish_reason != "null"
+                            && !finish_reason.is_empty()
+                        {
+                            stats_guard.finish_reason = Some(finish_reason.to_string());
+                        }
+
+                        // Track response size
+                        stats_guard.response_size_bytes += event.data.len();
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Stream error: {}", e);
+                }
+            }
+
+            // Pass through all events unchanged
+            match result {
+                Ok(event) => Some(Ok::<SseEvent, IngressError>(SseEvent {
+                    event: event.event,
+                    data: event.data,
+                })),
+                Err(e) => Some(Ok::<SseEvent, IngressError>(SseEvent {
+                    event: "error".into(),
+                    data: format!("error: {e}"),
+                })),
+            }
+        }
+    });
+
+    Ok(mapped_stream.boxed())
+}
+
 /// Passthrough handler for /v1/responses endpoint (OpenAI Responses API)
 /// Takes raw bytes, sends directly to OpenAI, returns raw response
 async fn responses_passthrough(
@@ -908,10 +1532,6 @@ async fn responses_passthrough(
 ) -> Result<Response, IngressError> {
     let start_time = std::time::Instant::now();
     tracing::debug!("OpenAI Responses API passthrough mode");
-
-    // Clone SSE config early before state is moved into closures
-    let sse_keepalive_interval = state.sse_keepalive_interval_secs;
-    let sse_keepalive_enabled_flag = state.sse_keepalive_enabled;
 
     // Extract user-agent from headers for session tracking
     // Truncate to 255 chars to prevent database issues with extremely long user agents
@@ -1029,13 +1649,16 @@ async fn responses_passthrough(
         None
     };
 
-    // Start session recording if enabled (using async events)
-    if let (Some(session_store), Some(session_id), Some(request_id), Some(req)) = (
-        &state.session_store,
-        &recording_session_id,
-        &recording_request_id,
-        &req_json,
-    ) {
+    // Start session recording if enabled (using async events).
+    // For streaming, session recording is handled inside responses_sse_stream.
+    if !is_streaming
+        && let (Some(session_store), Some(session_id), Some(request_id), Some(req)) = (
+            &state.session_store,
+            &recording_session_id,
+            &recording_request_id,
+            &req_json,
+        )
+    {
         use lunaroute_session::{SessionEvent, events::SessionMetadata as V2Metadata};
 
         // Write Started event asynchronously (spawn task for zero latency)
@@ -1211,394 +1834,30 @@ async fn responses_passthrough(
     }
 
     if is_streaming {
-        // Handle streaming passthrough for responses endpoint - pass raw bytes
-        let stream_response = match state
-            .connector
-            .stream_passthrough_to_endpoint_bytes("responses", body, passthrough_headers)
-            .await
-        {
-            Ok(response) => response,
-            Err(e) => {
-                // Record error in session if recording is enabled
-                if let (Some(session_store), Some(session_id), Some(request_id)) = (
-                    &state.session_store,
-                    &recording_session_id,
-                    &recording_request_id,
-                ) {
-                    use lunaroute_session::{SessionEvent, events::FinalSessionStats};
+        let sse_keepalive_interval = state.sse_keepalive_interval_secs;
+        let sse_keepalive_enabled_flag = state.sse_keepalive_enabled;
 
-                    // Record error asynchronously
-                    let store_clone = session_store.clone();
-                    let session_id_clone = session_id.clone();
-                    let request_id_clone = request_id.clone();
-                    let error_msg = e.to_string();
-                    let start_clone = start_time;
-                    tokio::spawn(async move {
-                        let duration = start_clone.elapsed();
-                        let event = SessionEvent::Completed {
-                            session_id: session_id_clone.clone(),
-                            request_id: request_id_clone,
-                            timestamp: chrono::Utc::now(),
-                            success: false,
-                            error: Some(error_msg),
-                            finish_reason: Some("error".to_string()),
-                            final_stats: Box::new(FinalSessionStats {
-                                total_duration_ms: duration.as_millis() as u64,
-                                provider_time_ms: 0,
-                                proxy_overhead_ms: duration.as_millis() as f64,
-                                total_tokens: Default::default(),
-                                tool_summary: Default::default(),
-                                performance: Default::default(),
-                                streaming_stats: None,
-                                estimated_cost: None,
-                            }),
-                        };
-                        if let Ok(json) = serde_json::to_value(event) {
-                            let _ = store_clone.write_event(None, json).await;
-                        }
-                    });
-                }
+        let event_stream =
+            responses_sse_stream(state.clone(), headers.clone(), body.clone()).await?;
 
-                // Handle provider errors by returning proper status codes
-                use lunaroute_egress::EgressError;
-                return match e {
-                    EgressError::ProviderError {
-                        status_code,
-                        message,
-                    } => {
-                        tracing::debug!("Provider returned error: {} - {}", status_code, message);
-                        // Parse error body as JSON if possible, otherwise wrap in error object
-                        let error_json = serde_json::from_str::<serde_json::Value>(&message)
-                            .unwrap_or_else(|_| {
-                                serde_json::json!({
-                                    "error": {
-                                        "message": message,
-                                        "type": "provider_error",
-                                        "code": status_code,
-                                    }
-                                })
-                            });
-                        Ok((
-                            axum::http::StatusCode::from_u16(status_code)
-                                .unwrap_or(axum::http::StatusCode::BAD_GATEWAY),
-                            Json(error_json),
-                        )
-                            .into_response())
-                    }
-                    _ => Err(IngressError::ProviderError(e.to_string())),
-                };
+        use axum::response::sse::{Event, KeepAlive, Sse};
+        use futures::StreamExt as _;
+        let axum_stream = event_stream.map(|result| match result {
+            Ok(ev) => {
+                Ok::<_, std::convert::Infallible>(Event::default().data(ev.data).event(ev.event))
             }
-        };
-
-        use futures::StreamExt;
-        let byte_stream = stream_response.bytes_stream();
-        let sse_stream = eventsource_stream::EventStream::new(byte_stream);
-
-        // Track token data and model from streaming events
-        use std::sync::{Arc, Mutex};
-
-        #[derive(Default, Clone)]
-        struct StreamingStats {
-            prompt_tokens: u64,
-            completion_tokens: u64,
-            total_tokens: u64,
-            model_used: Option<String>,
-            finish_reason: Option<String>,
-            response_size_bytes: usize,
-            stats_emitted: bool,
-            // Tool call tracking for Responses API
-            tool_calls: std::collections::HashMap<String, (String, String)>, // id -> (name, arguments)
-        }
-
-        let stats = Arc::new(Mutex::new(StreamingStats {
-            model_used: Some(model.clone()),
-            ..Default::default()
-        }));
-        let stats_clone = stats.clone();
-
-        // Clone session recording info for use in stream
-        let session_store_clone = state.session_store.clone();
-        let session_id_clone = recording_session_id.clone();
-        let request_id_clone = recording_request_id.clone();
-        let start_time_clone = start_time;
-        let user_agent_clone = user_agent.clone();
-        let tool_call_mapper_clone = state.tool_call_mapper.clone();
-
-        let mapped_stream = sse_stream.filter_map(move |result| {
-            // Clone Arc-wrapped values before async move
-            let stats_for_async = stats_clone.clone();
-            let session_store_for_async = session_store_clone.clone();
-            let session_id_for_async = session_id_clone.clone();
-            let request_id_for_async = request_id_clone.clone();
-            let user_agent_for_async = user_agent_clone.clone();
-            let start_time_for_async = start_time_clone;
-            let tool_call_mapper_for_async = tool_call_mapper_clone.clone();
-
-            async move {
-                match &result {
-                    Ok(event) => {
-                        // Try to parse event data as JSON to extract usage stats
-                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&event.data) {
-                            // Debug log to see event type and structure
-                            if !event.event.is_empty() {
-                                tracing::debug!("SSE event type: {}", event.event);
-                            }
-                            if let Some(response_type) = json.get("type").and_then(|t| t.as_str()) {
-                                tracing::debug!("Response type: {}", response_type);
-                            }
-
-                            let mut stats_guard = stats_for_async.lock().unwrap();
-
-                            // Extract tool calls from Responses API events
-                            if let Some(response_type) = json.get("type").and_then(|t| t.as_str()) {
-                                match response_type {
-                                    // When a function_call output item is added, extract call_id and name
-                                    "response.output_item.added" => {
-                                        if let Some(item) = json.get("item")
-                                            && let Some("function_call") =
-                                                item.get("type").and_then(|t| t.as_str())
-                                            && let (Some(call_id), Some(name)) = (
-                                                item.get("call_id").and_then(|id| id.as_str()),
-                                                item.get("name").and_then(|n| n.as_str()),
-                                            )
-                                        {
-                                            // Initialize tool call entry with name
-                                            stats_guard.tool_calls.insert(
-                                                call_id.to_string(),
-                                                (name.to_string(), String::new()),
-                                            );
-                                        }
-                                    }
-                                    // Accumulate function call arguments
-                                    "response.function_call_arguments.delta" => {
-                                        if let (Some(call_id), Some(arguments)) = (
-                                            json.get("call_id").and_then(|id| id.as_str()),
-                                            json.get("arguments").and_then(|a| a.as_str()),
-                                        ) && let Some(entry) =
-                                            stats_guard.tool_calls.get_mut(call_id)
-                                        {
-                                            entry.1.push_str(arguments);
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
-
-                            // Extract usage data if present (check both top-level and nested in response)
-                            let usage = json
-                                .get("usage")
-                                .or_else(|| json.get("response").and_then(|r| r.get("usage")));
-
-                            if let Some(usage) = usage {
-                                tracing::debug!("Found usage data in SSE event: {:?}", usage);
-                                // Responses API uses "input_tokens" and "output_tokens"
-                                // Chat Completions API uses "prompt_tokens" and "completion_tokens"
-                                stats_guard.prompt_tokens = usage
-                                    .get("input_tokens")
-                                    .or_else(|| usage.get("prompt_tokens"))
-                                    .and_then(|t| t.as_u64())
-                                    .unwrap_or(0);
-                                stats_guard.completion_tokens = usage
-                                    .get("output_tokens")
-                                    .or_else(|| usage.get("completion_tokens"))
-                                    .and_then(|t| t.as_u64())
-                                    .unwrap_or(0);
-                                stats_guard.total_tokens = usage
-                                    .get("total_tokens")
-                                    .and_then(|t| t.as_u64())
-                                    .unwrap_or(0);
-
-                                // Emit events when we receive usage data (only once)
-                                if !stats_guard.stats_emitted
-                                    && (stats_guard.prompt_tokens > 0
-                                        || stats_guard.completion_tokens > 0)
-                                {
-                                    stats_guard.stats_emitted = true;
-
-                                    // Clone data for async task
-                                    let session_store_task = session_store_for_async.clone();
-                                    let session_id_task = session_id_for_async.clone();
-                                    let request_id_task = request_id_for_async.clone();
-                                    let start_time_task = start_time_for_async;
-                                    let user_agent_task = user_agent_for_async.clone();
-                                    let prompt_tokens = stats_guard.prompt_tokens;
-                                    let completion_tokens = stats_guard.completion_tokens;
-                                    let total_tokens = stats_guard.total_tokens;
-                                    let model_used = stats_guard.model_used.clone();
-                                    let finish_reason = stats_guard.finish_reason.clone();
-                                    let response_size = stats_guard.response_size_bytes;
-                                    let tool_calls = stats_guard.tool_calls.clone();
-                                    let tool_call_mapper = tool_call_mapper_for_async.clone();
-
-                                    // Emit events asynchronously
-                                    if let (Some(store), Some(sid), Some(rid)) =
-                                        (session_store_task, session_id_task, request_id_task)
-                                    {
-                                        tokio::spawn(async move {
-                                            use lunaroute_session::{
-                                                SessionEvent,
-                                                events::{FinalSessionStats, TokenTotals},
-                                            };
-
-                                            // Emit StatsUpdated event
-                                            let token_updates = Some(TokenTotals {
-                                                total_input: prompt_tokens,
-                                                total_output: completion_tokens,
-                                                total_thinking: 0,
-                                                total_reasoning: 0,
-                                                total_cached: 0,
-                                                total_cache_read: 0,
-                                                total_cache_creation: 0,
-                                                total_audio_input: 0,
-                                                total_audio_output: 0,
-                                                grand_total: total_tokens,
-                                                by_model: Default::default(),
-                                            });
-
-                                            let stats_event = SessionEvent::StatsUpdated {
-                                                session_id: sid.clone(),
-                                                request_id: rid.clone(),
-                                                timestamp: chrono::Utc::now(),
-                                                token_updates,
-                                                tool_call_updates: None,
-                                                model_used: model_used.clone(),
-                                                response_size_bytes: response_size,
-                                                content_blocks: 1,
-                                                has_refusal: false,
-                                                user_agent: user_agent_task.clone(),
-                                            };
-
-                                            if let Ok(json) = serde_json::to_value(stats_event) {
-                                                let _ = store.write_event(None, json).await;
-                                            }
-
-                                            // Record and emit tool calls
-                                            for (tool_call_id, (tool_name, tool_arguments)) in
-                                                tool_calls
-                                            {
-                                                // Record to mapper for later lookup
-                                                tool_call_mapper.record_call(
-                                                    tool_call_id.clone(),
-                                                    tool_name.clone(),
-                                                );
-
-                                                // Emit ToolCallRecorded event
-                                                let input_size = tool_arguments.len();
-                                                let tool_call_event =
-                                                    SessionEvent::ToolCallRecorded {
-                                                        session_id: sid.clone(),
-                                                        request_id: rid.clone(),
-                                                        timestamp: chrono::Utc::now(),
-                                                        tool_name,
-                                                        tool_call_id,
-                                                        execution_time_ms: None,
-                                                        input_size_bytes: input_size,
-                                                        output_size_bytes: None,
-                                                        success: None,
-                                                        tool_arguments: Some(tool_arguments),
-                                                    };
-
-                                                if let Ok(json) =
-                                                    serde_json::to_value(tool_call_event)
-                                                {
-                                                    let _ = store.write_event(None, json).await;
-                                                }
-                                            }
-
-                                            // Emit Completed event
-                                            let duration = start_time_task.elapsed();
-                                            let completed_event = SessionEvent::Completed {
-                                                session_id: sid,
-                                                request_id: rid,
-                                                timestamp: chrono::Utc::now(),
-                                                success: true,
-                                                error: None,
-                                                finish_reason,
-                                                final_stats: Box::new(FinalSessionStats {
-                                                    total_duration_ms: duration.as_millis() as u64,
-                                                    provider_time_ms: duration.as_millis() as u64,
-                                                    proxy_overhead_ms: 0.0,
-                                                    total_tokens: TokenTotals {
-                                                        total_input: prompt_tokens,
-                                                        total_output: completion_tokens,
-                                                        total_thinking: 0,
-                                                        total_reasoning: 0,
-                                                        total_cached: 0,
-                                                        total_cache_read: 0,
-                                                        total_cache_creation: 0,
-                                                        total_audio_input: 0,
-                                                        total_audio_output: 0,
-                                                        grand_total: total_tokens,
-                                                        by_model: Default::default(),
-                                                    },
-                                                    tool_summary: Default::default(),
-                                                    performance: Default::default(),
-                                                    streaming_stats: None,
-                                                    estimated_cost: None,
-                                                }),
-                                            };
-
-                                            if let Ok(json) = serde_json::to_value(completed_event)
-                                            {
-                                                let _ = store.write_event(None, json).await;
-                                            }
-                                        });
-                                    }
-                                }
-                            }
-
-                            // Extract model if present
-                            if let Some(model) = json.get("model").and_then(|m| m.as_str()) {
-                                stats_guard.model_used = Some(model.to_string());
-                            }
-
-                            // Extract finish_reason if present
-                            if let Some(choices) = json.get("choices").and_then(|c| c.as_array())
-                                && let Some(choice) = choices.first()
-                                && let Some(finish_reason) =
-                                    choice.get("finish_reason").and_then(|fr| fr.as_str())
-                                && finish_reason != "null"
-                                && !finish_reason.is_empty()
-                            {
-                                stats_guard.finish_reason = Some(finish_reason.to_string());
-                            }
-
-                            // Track response size
-                            stats_guard.response_size_bytes += event.data.len();
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!("Stream error: {}", e);
-                    }
-                }
-
-                // Pass through all events unchanged
-                match result {
-                    Ok(event) => Some(
-                        Ok::<_, eventsource_stream::EventStreamError<std::io::Error>>(
-                            Event::default().data(event.data).event(event.event),
-                        ),
-                    ),
-                    Err(e) => Some(
-                        Ok::<_, eventsource_stream::EventStreamError<std::io::Error>>(
-                            Event::default().data(format!("error: {}", e)),
-                        ),
-                    ),
-                }
+            Err(e) => {
+                Ok::<_, std::convert::Infallible>(Event::default().data(format!("error: {e}")))
             }
         });
 
-        // Create SSE response with configured keepalive
-        let sse_keepalive = if sse_keepalive_enabled_flag {
+        let keepalive = if sse_keepalive_enabled_flag {
             KeepAlive::new().interval(std::time::Duration::from_secs(sse_keepalive_interval))
         } else {
-            // Disable keepalive by setting a very long interval
-            KeepAlive::new().interval(std::time::Duration::from_secs(86400)) // 24 hours
+            KeepAlive::new().interval(std::time::Duration::from_secs(86400))
         };
 
-        Ok(Sse::new(mapped_stream)
-            .keep_alive(sse_keepalive)
-            .into_response())
+        Ok(Sse::new(axum_stream).keep_alive(keepalive).into_response())
     } else {
         // Send directly to OpenAI API (non-streaming) - pass raw bytes
         match state

--- a/crates/lunaroute-ingress/src/openai.rs
+++ b/crates/lunaroute-ingress/src/openai.rs
@@ -8,7 +8,7 @@ use axum::{
         IntoResponse, Response,
         sse::{Event, KeepAlive, Sse},
     },
-    routing::post,
+    routing::{get, post},
 };
 use futures::StreamExt;
 #[cfg(test)]
@@ -2228,10 +2228,18 @@ pub fn passthrough_router(
 
     Router::new()
         .route("/v1/chat/completions", post(chat_completions_passthrough))
-        .route("/v1/responses", post(responses_passthrough))
-        .route("/responses", post(responses_passthrough)) // For Codex compatibility (base_url without /v1)
-        .route("/v1/models", axum::routing::get(models_passthrough))
-        .route("/models", axum::routing::get(models_passthrough)) // For Codex compatibility (base_url without /v1)
+        .route(
+            "/v1/responses",
+            post(responses_passthrough).get(crate::responses_ws::responses_ws_handler),
+        )
+        // Codex compat: base_url without /v1
+        .route(
+            "/responses",
+            post(responses_passthrough).get(crate::responses_ws::responses_ws_handler),
+        )
+        .route("/v1/models", get(models_passthrough))
+        // Codex compat: base_url without /v1
+        .route("/models", get(models_passthrough))
         .layer(tower_http::compression::CompressionLayer::new())
         .with_state(state)
 }

--- a/crates/lunaroute-ingress/src/openai.rs
+++ b/crates/lunaroute-ingress/src/openai.rs
@@ -1217,8 +1217,17 @@ pub(crate) async fn responses_sse_stream(
                     message,
                 } => {
                     tracing::debug!("Provider returned error: {} - {}", status_code, message);
-                    let body: serde_json::Value = serde_json::from_str(&message)
-                        .unwrap_or(serde_json::Value::String(message));
+                    // Parse error body as JSON if possible, otherwise wrap in error object
+                    let body: serde_json::Value =
+                        serde_json::from_str(&message).unwrap_or_else(|_| {
+                            serde_json::json!({
+                                "error": {
+                                    "message": message,
+                                    "type": "provider_error",
+                                    "code": status_code,
+                                }
+                            })
+                        });
                     Err(IngressError::ProviderErrorResponse {
                         status: status_code,
                         body,

--- a/crates/lunaroute-ingress/src/openai.rs
+++ b/crates/lunaroute-ingress/src/openai.rs
@@ -1217,9 +1217,11 @@ pub(crate) async fn responses_sse_stream(
                     message,
                 } => {
                     tracing::debug!("Provider returned error: {} - {}", status_code, message);
+                    let body: serde_json::Value = serde_json::from_str(&message)
+                        .unwrap_or(serde_json::Value::String(message));
                     Err(IngressError::ProviderErrorResponse {
                         status: status_code,
-                        message,
+                        body,
                     })
                 }
                 _ => Err(IngressError::ProviderError(e.to_string())),
@@ -1513,7 +1515,7 @@ pub(crate) async fn responses_sse_stream(
                     data: event.data,
                 })),
                 Err(e) => Some(Ok::<SseEvent, IngressError>(SseEvent {
-                    event: "error".into(),
+                    event: String::new(),
                     data: format!("error: {e}"),
                 })),
             }
@@ -1844,7 +1846,13 @@ async fn responses_passthrough(
         use futures::StreamExt as _;
         let axum_stream = event_stream.map(|result| match result {
             Ok(ev) => {
-                Ok::<_, std::convert::Infallible>(Event::default().data(ev.data).event(ev.event))
+                let base = Event::default().data(ev.data);
+                let axum_ev = if ev.event.is_empty() {
+                    base
+                } else {
+                    base.event(ev.event)
+                };
+                Ok::<_, std::convert::Infallible>(axum_ev)
             }
             Err(e) => {
                 Ok::<_, std::convert::Infallible>(Event::default().data(format!("error: {e}")))

--- a/crates/lunaroute-ingress/src/responses_ws.rs
+++ b/crates/lunaroute-ingress/src/responses_ws.rs
@@ -106,6 +106,12 @@ async fn run_ws_session(
     state: Arc<OpenAIPassthroughState>,
     upgrade_headers: HeaderMap,
 ) {
+    const ENDPOINT: &str = "responses";
+    let started = std::time::Instant::now();
+    if let Some(metrics) = &state.metrics {
+        metrics.record_ws_connection_opened(ENDPOINT);
+    }
+
     tracing::debug!("WS session started");
 
     while let Some(msg) = socket.recv().await {
@@ -119,6 +125,9 @@ async fn run_ws_session(
 
         match msg {
             Message::Text(text) => {
+                if let Some(metrics) = &state.metrics {
+                    metrics.record_ws_frame(ENDPOINT, "client", "text");
+                }
                 if let Err(e) =
                     handle_client_text(&mut socket, &state, &upgrade_headers, text.as_ref()).await
                 {
@@ -145,7 +154,10 @@ async fn run_ws_session(
         }
     }
 
-    tracing::debug!("WS session ended");
+    if let Some(metrics) = &state.metrics {
+        metrics.record_ws_connection_closed(ENDPOINT, started.elapsed().as_secs_f64());
+    }
+    tracing::debug!("WS session ended after {:?}", started.elapsed());
 }
 
 /// Dispatch one client text frame: parse, run the pipeline, forward events.
@@ -201,7 +213,7 @@ async fn handle_client_text(
                 }
             };
 
-            forward_stream(socket, stream).await
+            forward_stream(socket, state, stream).await
         }
     }
 }
@@ -210,11 +222,21 @@ async fn handle_client_text(
 /// event is seen or the stream ends.
 async fn forward_stream(
     socket: &mut WebSocket,
+    state: &Arc<OpenAIPassthroughState>,
     mut stream: futures::stream::BoxStream<'static, Result<SseEvent, crate::IngressError>>,
 ) -> Result<(), axum::Error> {
+    const ENDPOINT: &str = "responses";
     while let Some(result) = stream.next().await {
         match result {
             Ok(ev) => {
+                if let Some(metrics) = &state.metrics {
+                    let ty = if ev.event.is_empty() {
+                        "message"
+                    } else {
+                        ev.event.as_str()
+                    };
+                    metrics.record_ws_frame(ENDPOINT, "server", ty);
+                }
                 // Send just the `data` payload — the event name is already
                 // embedded in the JSON's `type` field per the Responses WS spec.
                 socket.send(Message::Text(ev.data.clone().into())).await?;

--- a/crates/lunaroute-ingress/src/responses_ws.rs
+++ b/crates/lunaroute-ingress/src/responses_ws.rs
@@ -1,0 +1,133 @@
+//! WebSocket ingress for OpenAI's Responses API.
+//!
+//! Codex CLI (with `supports_websockets = true`) opens a WebSocket to
+//! `/v1/responses`. This module accepts the upgrade, parses `response.create`
+//! frames, and drives the same HTTP streaming pipeline used by
+//! `openai::responses_passthrough` via `openai::responses_sse_stream`.
+//!
+//! See `docs/superpowers/specs/2026-04-16-codex-websocket-responses-design.md`.
+
+use serde::Deserialize;
+
+/// Parsed client-to-server WebSocket frame.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) enum ClientEvent {
+    /// `{"type": "response.create", "response": {...}}` — create a response.
+    /// The inner `response` object is the usual Responses API create payload.
+    ResponseCreate { response: serde_json::Value },
+}
+
+/// Error returned by `parse_client_frame`.
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)]
+pub(crate) enum FrameError {
+    #[error("malformed JSON: {0}")]
+    MalformedJson(#[from] serde_json::Error),
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+    #[error("unsupported event type: {0}")]
+    UnsupportedType(String),
+}
+
+/// Parse a client text frame into a `ClientEvent`.
+///
+/// Accepted shape: `{"type": "response.create", "response": {...}}` with
+/// `response` being any JSON object (the Responses API create body). Anything
+/// else returns a `FrameError` the caller maps to a structured error frame.
+#[allow(dead_code)]
+pub(crate) fn parse_client_frame(text: &str) -> Result<ClientEvent, FrameError> {
+    #[derive(Deserialize)]
+    struct Envelope {
+        r#type: String,
+        #[serde(default)]
+        response: Option<serde_json::Value>,
+    }
+
+    let envelope: Envelope = serde_json::from_str(text)?;
+    match envelope.r#type.as_str() {
+        "response.create" => {
+            let response = envelope
+                .response
+                .ok_or(FrameError::MissingField("response"))?;
+            if !response.is_object() {
+                return Err(FrameError::MissingField("response (must be object)"));
+            }
+            Ok(ClientEvent::ResponseCreate { response })
+        }
+        other => Err(FrameError::UnsupportedType(other.to_string())),
+    }
+}
+
+/// Build a server-side error frame payload in the Responses API event shape.
+#[allow(dead_code)]
+pub(crate) fn error_frame(code: &str, message: &str) -> String {
+    serde_json::json!({
+        "type": "error",
+        "error": {
+            "code": code,
+            "message": message,
+        }
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_response_create() {
+        let text = r#"{"type":"response.create","response":{"model":"gpt-5","input":"hi"}}"#;
+        let ev = parse_client_frame(text).unwrap();
+        match ev {
+            ClientEvent::ResponseCreate { response } => {
+                assert_eq!(
+                    response.get("model").and_then(|v| v.as_str()),
+                    Some("gpt-5")
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_type() {
+        let text = r#"{"type":"response.cancel"}"#;
+        let err = parse_client_frame(text).unwrap_err();
+        assert!(matches!(err, FrameError::UnsupportedType(ref t) if t == "response.cancel"));
+    }
+
+    #[test]
+    fn rejects_missing_response_field() {
+        let text = r#"{"type":"response.create"}"#;
+        let err = parse_client_frame(text).unwrap_err();
+        assert!(matches!(err, FrameError::MissingField("response")));
+    }
+
+    #[test]
+    fn rejects_non_object_response() {
+        let text = r#"{"type":"response.create","response":"not-an-object"}"#;
+        let err = parse_client_frame(text).unwrap_err();
+        assert!(matches!(err, FrameError::MissingField(_)));
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let err = parse_client_frame("{not json").unwrap_err();
+        assert!(matches!(err, FrameError::MalformedJson(_)));
+    }
+
+    #[test]
+    fn error_frame_has_expected_shape() {
+        let frame = error_frame("unsupported_event_type", "nope");
+        let value: serde_json::Value = serde_json::from_str(&frame).unwrap();
+        assert_eq!(value.get("type").and_then(|v| v.as_str()), Some("error"));
+        assert_eq!(
+            value
+                .get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|v| v.as_str()),
+            Some("unsupported_event_type")
+        );
+    }
+}

--- a/crates/lunaroute-ingress/src/responses_ws.rs
+++ b/crates/lunaroute-ingress/src/responses_ws.rs
@@ -123,11 +123,13 @@ async fn run_ws_session(
             }
         };
 
+        // Note: `ws_frames_total` tracks application-level activity, so we
+        // count Text frames only after a successful parse (in
+        // `handle_client_text`), plus Binary frames here as `"binary"`.
+        // Ping/Pong/Close are transport-level frames — not counted, since they
+        // aren't useful signals for application dashboards.
         match msg {
             Message::Text(text) => {
-                if let Some(metrics) = &state.metrics {
-                    metrics.record_ws_frame(ENDPOINT, "client", "text");
-                }
                 if let Err(e) =
                     handle_client_text(&mut socket, &state, &upgrade_headers, text.as_ref()).await
                 {
@@ -144,8 +146,12 @@ async fn run_ws_session(
                 // axum handles ping/pong automatically; nothing to do.
             }
             Message::Binary(_) => {
+                if let Some(metrics) = &state.metrics {
+                    metrics.record_ws_frame(ENDPOINT, "client", "binary");
+                }
                 let _ = send_error(
                     &mut socket,
+                    &state,
                     "unsupported_frame_type",
                     "binary frames are not supported",
                 )
@@ -167,17 +173,29 @@ async fn handle_client_text(
     upgrade_headers: &HeaderMap,
     text: &str,
 ) -> Result<(), axum::Error> {
+    const ENDPOINT: &str = "responses";
     let event = match parse_client_frame(text) {
         Ok(e) => e,
+        // Invalid frames are not counted under `ws_frames_total` — that
+        // counter tracks successful application-level events. The
+        // corresponding outbound error frame is counted as `type="error"` on
+        // the server direction by `send_error` instead.
         Err(FrameError::MalformedJson(e)) => {
-            return send_error(socket, "malformed_json", &e.to_string()).await;
+            return send_error(socket, state, "malformed_json", &e.to_string()).await;
         }
         Err(FrameError::MissingField(f)) => {
-            return send_error(socket, "invalid_request", &format!("missing field: {f}")).await;
+            return send_error(
+                socket,
+                state,
+                "invalid_request",
+                &format!("missing field: {f}"),
+            )
+            .await;
         }
         Err(FrameError::UnsupportedType(t)) => {
             return send_error(
                 socket,
+                state,
                 "unsupported_event_type",
                 &format!("unsupported event type: {t}"),
             )
@@ -187,6 +205,9 @@ async fn handle_client_text(
 
     match event {
         ClientEvent::ResponseCreate { mut response } => {
+            if let Some(metrics) = &state.metrics {
+                metrics.record_ws_frame(ENDPOINT, "client", "response.create");
+            }
             // Force stream=true unconditionally: the WebSocket transport is
             // inherently streaming; a client-supplied {"stream": false} would
             // break the pipeline.
@@ -194,7 +215,7 @@ async fn handle_client_text(
             let body_bytes = match serde_json::to_vec(&response) {
                 Ok(b) => axum::body::Bytes::from(b),
                 Err(e) => {
-                    return send_error(socket, "internal_error", &e.to_string()).await;
+                    return send_error(socket, state, "internal_error", &e.to_string()).await;
                 }
             };
 
@@ -209,7 +230,7 @@ async fn handle_client_text(
             let stream = match responses_sse_stream(state.clone(), ws_headers, body_bytes).await {
                 Ok(s) => s,
                 Err(e) => {
-                    return send_error(socket, "upstream_error", &e.to_string()).await;
+                    return send_error(socket, state, "upstream_error", &e.to_string()).await;
                 }
             };
 
@@ -230,12 +251,8 @@ async fn forward_stream(
         match result {
             Ok(ev) => {
                 if let Some(metrics) = &state.metrics {
-                    let ty = if ev.event.is_empty() {
-                        "message"
-                    } else {
-                        ev.event.as_str()
-                    };
-                    metrics.record_ws_frame(ENDPOINT, "server", ty);
+                    let ty = event_label(&ev);
+                    metrics.record_ws_frame(ENDPOINT, "server", &ty);
                 }
                 // Send just the `data` payload — the event name is already
                 // embedded in the JSON's `type` field per the Responses WS spec.
@@ -245,7 +262,7 @@ async fn forward_stream(
                 }
             }
             Err(e) => {
-                return send_error(socket, "stream_error", &e.to_string()).await;
+                return send_error(socket, state, "stream_error", &e.to_string()).await;
             }
         }
     }
@@ -253,10 +270,30 @@ async fn forward_stream(
     // client doesn't hang waiting.
     send_error(
         socket,
+        state,
         "stream_ended",
         "upstream stream ended without a terminal event",
     )
     .await
+}
+
+/// Derive the `type` label for `ws_frames_total` from a server-side SSE event.
+///
+/// Prefers the Responses API event type embedded in `ev.data`'s `type` field
+/// (e.g. `response.output_text.delta`, `response.completed`). Falls back to
+/// the SSE `event:` name, and finally to `"message"` for an otherwise opaque
+/// frame. Keeps cardinality bounded to the Responses API vocabulary.
+fn event_label(ev: &SseEvent) -> String {
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&ev.data)
+        && let Some(t) = value.get("type").and_then(|v| v.as_str())
+        && !t.is_empty()
+    {
+        return t.to_string();
+    }
+    if !ev.event.is_empty() {
+        return ev.event.clone();
+    }
+    "message".to_string()
 }
 
 fn is_terminal(ev: &SseEvent) -> bool {
@@ -272,7 +309,18 @@ fn is_terminal(ev: &SseEvent) -> bool {
     false
 }
 
-async fn send_error(socket: &mut WebSocket, code: &str, message: &str) -> Result<(), axum::Error> {
+async fn send_error(
+    socket: &mut WebSocket,
+    state: &Arc<OpenAIPassthroughState>,
+    code: &str,
+    message: &str,
+) -> Result<(), axum::Error> {
+    // Error frames are server-originated and represent abnormal application
+    // activity — count them so they show up in dashboards alongside normal
+    // `response.*` event types.
+    if let Some(metrics) = &state.metrics {
+        metrics.record_ws_frame("responses", "server", "error");
+    }
     socket
         .send(Message::Text(error_frame(code, message).into()))
         .await

--- a/crates/lunaroute-ingress/src/responses_ws.rs
+++ b/crates/lunaroute-ingress/src/responses_ws.rs
@@ -175,10 +175,10 @@ async fn handle_client_text(
 
     match event {
         ClientEvent::ResponseCreate { mut response } => {
-            // Force stream=true: upstream HTTP needs it for streaming.
-            if response.get("stream").is_none() {
-                response["stream"] = serde_json::Value::Bool(true);
-            }
+            // Force stream=true unconditionally: the WebSocket transport is
+            // inherently streaming; a client-supplied {"stream": false} would
+            // break the pipeline.
+            response["stream"] = serde_json::Value::Bool(true);
             let body_bytes = match serde_json::to_vec(&response) {
                 Ok(b) => axum::body::Bytes::from(b),
                 Err(e) => {
@@ -186,13 +186,15 @@ async fn handle_client_text(
                 }
             };
 
-            let stream = match responses_sse_stream(
-                state.clone(),
-                upgrade_headers.clone(),
-                body_bytes,
-            )
-            .await
-            {
+            // The upgrade is a GET with no body, so Content-Type is absent.
+            // Inject it so the upstream POST is handled as JSON.
+            let mut ws_headers = upgrade_headers.clone();
+            ws_headers.insert(
+                axum::http::header::CONTENT_TYPE,
+                axum::http::HeaderValue::from_static("application/json"),
+            );
+
+            let stream = match responses_sse_stream(state.clone(), ws_headers, body_bytes).await {
                 Ok(s) => s,
                 Err(e) => {
                     return send_error(socket, "upstream_error", &e.to_string()).await;

--- a/crates/lunaroute-ingress/src/responses_ws.rs
+++ b/crates/lunaroute-ingress/src/responses_ws.rs
@@ -123,11 +123,11 @@ async fn run_ws_session(
             }
         };
 
-        // Note: `ws_frames_total` tracks application-level activity, so we
-        // count Text frames only after a successful parse (in
-        // `handle_client_text`), plus Binary frames here as `"binary"`.
-        // Ping/Pong/Close are transport-level frames — not counted, since they
-        // aren't useful signals for application dashboards.
+        // Note: `ws_frames_total` tracks application-level activity. Text
+        // frames are counted inside `handle_client_text` (once per inbound
+        // frame, labeled by parse outcome), plus Binary frames here as
+        // `"binary"`. Ping/Pong/Close are transport-level frames — not counted,
+        // since they aren't useful signals for application dashboards.
         match msg {
             Message::Text(text) => {
                 if let Err(e) =
@@ -176,14 +176,16 @@ async fn handle_client_text(
     const ENDPOINT: &str = "responses";
     let event = match parse_client_frame(text) {
         Ok(e) => e,
-        // Invalid frames are not counted under `ws_frames_total` — that
-        // counter tracks successful application-level events. The
-        // corresponding outbound error frame is counted as `type="error"` on
-        // the server direction by `send_error` instead.
         Err(FrameError::MalformedJson(e)) => {
+            if let Some(metrics) = &state.metrics {
+                metrics.record_ws_frame(ENDPOINT, "client", "malformed_json");
+            }
             return send_error(socket, state, "malformed_json", &e.to_string()).await;
         }
         Err(FrameError::MissingField(f)) => {
+            if let Some(metrics) = &state.metrics {
+                metrics.record_ws_frame(ENDPOINT, "client", "invalid_request");
+            }
             return send_error(
                 socket,
                 state,
@@ -193,6 +195,9 @@ async fn handle_client_text(
             .await;
         }
         Err(FrameError::UnsupportedType(t)) => {
+            if let Some(metrics) = &state.metrics {
+                metrics.record_ws_frame(ENDPOINT, "client", "unsupported_event_type");
+            }
             return send_error(
                 socket,
                 state,
@@ -383,5 +388,65 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("unsupported_event_type")
         );
+    }
+
+    // Note: integration tests that exercise the `ws_frames_total`
+    // instrumentation end-to-end would require threading a real `Metrics`
+    // through the test `passthrough_router`, which is out of scope for this
+    // fix. The unit tests below pin the `event_label` precedence that those
+    // instrumentation paths depend on.
+
+    #[test]
+    fn event_label_prefers_json_type_over_sse_event() {
+        let ev = SseEvent {
+            event: "response.output_text.delta".to_string(),
+            data: r#"{"type":"response.completed"}"#.to_string(),
+        };
+        assert_eq!(event_label(&ev), "response.completed");
+    }
+
+    #[test]
+    fn event_label_falls_back_to_sse_event_when_data_not_json() {
+        let ev = SseEvent {
+            event: "response.output_text.delta".to_string(),
+            data: "not-json".to_string(),
+        };
+        assert_eq!(event_label(&ev), "response.output_text.delta");
+    }
+
+    #[test]
+    fn event_label_falls_back_to_sse_event_when_json_has_no_type() {
+        let ev = SseEvent {
+            event: "custom.event".to_string(),
+            data: r#"{"foo":"bar"}"#.to_string(),
+        };
+        assert_eq!(event_label(&ev), "custom.event");
+    }
+
+    #[test]
+    fn event_label_falls_back_to_sse_event_when_json_type_empty() {
+        let ev = SseEvent {
+            event: "custom.event".to_string(),
+            data: r#"{"type":""}"#.to_string(),
+        };
+        assert_eq!(event_label(&ev), "custom.event");
+    }
+
+    #[test]
+    fn event_label_returns_message_when_both_empty() {
+        let ev = SseEvent {
+            event: String::new(),
+            data: String::new(),
+        };
+        assert_eq!(event_label(&ev), "message");
+    }
+
+    #[test]
+    fn event_label_returns_message_when_data_not_json_and_event_empty() {
+        let ev = SseEvent {
+            event: String::new(),
+            data: "not-json".to_string(),
+        };
+        assert_eq!(event_label(&ev), "message");
     }
 }

--- a/crates/lunaroute-ingress/src/responses_ws.rs
+++ b/crates/lunaroute-ingress/src/responses_ws.rs
@@ -7,11 +7,18 @@
 //!
 //! See `docs/superpowers/specs/2026-04-16-codex-websocket-responses-design.md`.
 
+use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::http::HeaderMap;
+use axum::response::Response;
+use futures::StreamExt as _;
 use serde::Deserialize;
+use std::sync::Arc;
+
+use crate::openai::{OpenAIPassthroughState, SseEvent, responses_sse_stream};
 
 /// Parsed client-to-server WebSocket frame.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub(crate) enum ClientEvent {
     /// `{"type": "response.create", "response": {...}}` — create a response.
     /// The inner `response` object is the usual Responses API create payload.
@@ -20,7 +27,6 @@ pub(crate) enum ClientEvent {
 
 /// Error returned by `parse_client_frame`.
 #[derive(Debug, thiserror::Error)]
-#[allow(dead_code)]
 pub(crate) enum FrameError {
     #[error("malformed JSON: {0}")]
     MalformedJson(#[from] serde_json::Error),
@@ -35,7 +41,6 @@ pub(crate) enum FrameError {
 /// Accepted shape: `{"type": "response.create", "response": {...}}` with
 /// `response` being any JSON object (the Responses API create body). Anything
 /// else returns a `FrameError` the caller maps to a structured error frame.
-#[allow(dead_code)]
 pub(crate) fn parse_client_frame(text: &str) -> Result<ClientEvent, FrameError> {
     #[derive(Deserialize)]
     struct Envelope {
@@ -60,7 +65,6 @@ pub(crate) fn parse_client_frame(text: &str) -> Result<ClientEvent, FrameError> 
 }
 
 /// Build a server-side error frame payload in the Responses API event shape.
-#[allow(dead_code)]
 pub(crate) fn error_frame(code: &str, message: &str) -> String {
     serde_json::json!({
         "type": "error",
@@ -70,6 +74,184 @@ pub(crate) fn error_frame(code: &str, message: &str) -> String {
         }
     })
     .to_string()
+}
+
+/// Terminal Responses API event types — receiving one of these means the
+/// current response is finished and the read loop may accept the next
+/// `response.create` frame on the same connection.
+const TERMINAL_EVENTS: &[&str] = &[
+    "response.completed",
+    "response.failed",
+    "response.incomplete",
+    "response.cancelled",
+];
+
+/// axum handler: accept the WebSocket upgrade on `/responses` or
+/// `/v1/responses` and spawn a per-connection session.
+pub async fn responses_ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<OpenAIPassthroughState>>,
+    headers: HeaderMap,
+) -> Response {
+    tracing::debug!("Responses API WebSocket upgrade");
+    ws.on_upgrade(move |socket| run_ws_session(socket, state, headers))
+}
+
+/// Own the socket for a single WebSocket connection. Reads client frames,
+/// runs each `response.create` through the shared SSE pipeline, sends each
+/// resulting event back as a WS text frame. Sequential by construction — we
+/// await each stream to completion before the next `recv`.
+async fn run_ws_session(
+    mut socket: WebSocket,
+    state: Arc<OpenAIPassthroughState>,
+    upgrade_headers: HeaderMap,
+) {
+    tracing::debug!("WS session started");
+
+    while let Some(msg) = socket.recv().await {
+        let msg = match msg {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!("WS recv error: {e}");
+                break;
+            }
+        };
+
+        match msg {
+            Message::Text(text) => {
+                if let Err(e) =
+                    handle_client_text(&mut socket, &state, &upgrade_headers, text.as_ref()).await
+                {
+                    tracing::warn!("WS text handling error: {e}");
+                    // Connection stays open unless the error indicates a send failure
+                    // (in which case the next recv will fail too).
+                }
+            }
+            Message::Close(_) => {
+                tracing::debug!("WS client closed");
+                break;
+            }
+            Message::Ping(_) | Message::Pong(_) => {
+                // axum handles ping/pong automatically; nothing to do.
+            }
+            Message::Binary(_) => {
+                let _ = send_error(
+                    &mut socket,
+                    "unsupported_frame_type",
+                    "binary frames are not supported",
+                )
+                .await;
+            }
+        }
+    }
+
+    tracing::debug!("WS session ended");
+}
+
+/// Dispatch one client text frame: parse, run the pipeline, forward events.
+async fn handle_client_text(
+    socket: &mut WebSocket,
+    state: &Arc<OpenAIPassthroughState>,
+    upgrade_headers: &HeaderMap,
+    text: &str,
+) -> Result<(), axum::Error> {
+    let event = match parse_client_frame(text) {
+        Ok(e) => e,
+        Err(FrameError::MalformedJson(e)) => {
+            return send_error(socket, "malformed_json", &e.to_string()).await;
+        }
+        Err(FrameError::MissingField(f)) => {
+            return send_error(socket, "invalid_request", &format!("missing field: {f}")).await;
+        }
+        Err(FrameError::UnsupportedType(t)) => {
+            return send_error(
+                socket,
+                "unsupported_event_type",
+                &format!("unsupported event type: {t}"),
+            )
+            .await;
+        }
+    };
+
+    match event {
+        ClientEvent::ResponseCreate { mut response } => {
+            // Force stream=true: upstream HTTP needs it for streaming.
+            if response.get("stream").is_none() {
+                response["stream"] = serde_json::Value::Bool(true);
+            }
+            let body_bytes = match serde_json::to_vec(&response) {
+                Ok(b) => axum::body::Bytes::from(b),
+                Err(e) => {
+                    return send_error(socket, "internal_error", &e.to_string()).await;
+                }
+            };
+
+            let stream = match responses_sse_stream(
+                state.clone(),
+                upgrade_headers.clone(),
+                body_bytes,
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    return send_error(socket, "upstream_error", &e.to_string()).await;
+                }
+            };
+
+            forward_stream(socket, stream).await
+        }
+    }
+}
+
+/// Forward a stream of `SseEvent`s as WebSocket text frames until a terminal
+/// event is seen or the stream ends.
+async fn forward_stream(
+    socket: &mut WebSocket,
+    mut stream: futures::stream::BoxStream<'static, Result<SseEvent, crate::IngressError>>,
+) -> Result<(), axum::Error> {
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(ev) => {
+                // Send just the `data` payload — the event name is already
+                // embedded in the JSON's `type` field per the Responses WS spec.
+                socket.send(Message::Text(ev.data.clone().into())).await?;
+                if is_terminal(&ev) {
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                return send_error(socket, "stream_error", &e.to_string()).await;
+            }
+        }
+    }
+    // Stream ended with no terminal event — emit a synthetic error so the
+    // client doesn't hang waiting.
+    send_error(
+        socket,
+        "stream_ended",
+        "upstream stream ended without a terminal event",
+    )
+    .await
+}
+
+fn is_terminal(ev: &SseEvent) -> bool {
+    if TERMINAL_EVENTS.contains(&ev.event.as_str()) {
+        return true;
+    }
+    // Fall back to inspecting the JSON `type` field inside `data`.
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&ev.data)
+        && let Some(t) = value.get("type").and_then(|v| v.as_str())
+    {
+        return TERMINAL_EVENTS.contains(&t);
+    }
+    false
+}
+
+async fn send_error(socket: &mut WebSocket, code: &str, message: &str) -> Result<(), axum::Error> {
+    socket
+        .send(Message::Text(error_frame(code, message).into()))
+        .await
 }
 
 #[cfg(test)]

--- a/crates/lunaroute-ingress/src/types.rs
+++ b/crates/lunaroute-ingress/src/types.rs
@@ -145,6 +145,10 @@ pub enum IngressError {
     /// Provider error
     #[error("Provider error: {0}")]
     ProviderError(String),
+
+    /// Provider returned a non-success HTTP response; status code is preserved.
+    #[error("Provider error {status}: {message}")]
+    ProviderErrorResponse { status: u16, message: String },
 }
 
 impl axum::response::IntoResponse for IngressError {
@@ -167,6 +171,10 @@ impl axum::response::IntoResponse for IngressError {
             IngressError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             IngressError::UnsupportedFeature(msg) => (StatusCode::NOT_IMPLEMENTED, msg),
             IngressError::ProviderError(msg) => (StatusCode::BAD_GATEWAY, msg),
+            IngressError::ProviderErrorResponse { status, message } => (
+                StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
+                message,
+            ),
         };
 
         let body = serde_json::json!({

--- a/crates/lunaroute-ingress/src/types.rs
+++ b/crates/lunaroute-ingress/src/types.rs
@@ -146,14 +146,23 @@ pub enum IngressError {
     #[error("Provider error: {0}")]
     ProviderError(String),
 
-    /// Provider returned a non-success HTTP response; status code is preserved.
-    #[error("Provider error {status}: {message}")]
-    ProviderErrorResponse { status: u16, message: String },
+    /// Provider returned a non-success HTTP response; status code and body are preserved verbatim.
+    #[error("Provider error {status}")]
+    ProviderErrorResponse {
+        status: u16,
+        body: serde_json::Value,
+    },
 }
 
 impl axum::response::IntoResponse for IngressError {
     fn into_response(self) -> axum::response::Response {
         use axum::http::StatusCode;
+
+        // ProviderErrorResponse forwards the provider's JSON body unchanged.
+        if let IngressError::ProviderErrorResponse { status, body } = self {
+            let status_code = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
+            return (status_code, axum::Json(body)).into_response();
+        }
 
         let (status, message) = match self {
             IngressError::InvalidRequest(msg) => (StatusCode::BAD_REQUEST, msg),
@@ -171,10 +180,7 @@ impl axum::response::IntoResponse for IngressError {
             IngressError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             IngressError::UnsupportedFeature(msg) => (StatusCode::NOT_IMPLEMENTED, msg),
             IngressError::ProviderError(msg) => (StatusCode::BAD_GATEWAY, msg),
-            IngressError::ProviderErrorResponse { status, message } => (
-                StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY),
-                message,
-            ),
+            IngressError::ProviderErrorResponse { .. } => unreachable!("handled above"),
         };
 
         let body = serde_json::json!({

--- a/crates/lunaroute-integration-tests/Cargo.toml
+++ b/crates/lunaroute-integration-tests/Cargo.toml
@@ -31,3 +31,4 @@ reqwest = { workspace = true }
 [dev-dependencies]
 dotenv = "0.15"
 tracing-subscriber = { workspace = true }
+tokio-tungstenite = { workspace = true }

--- a/crates/lunaroute-integration-tests/tests/responses_websocket.rs
+++ b/crates/lunaroute-integration-tests/tests/responses_websocket.rs
@@ -15,7 +15,7 @@ use lunaroute_session::SessionEvent;
 use serde_json::json;
 use std::sync::Arc;
 use tokio_tungstenite::tungstenite::Message;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_partial_json, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Bind the passthrough router to a random localhost port and return the port.
@@ -67,8 +67,13 @@ async fn ws_connect(
 async fn ws_response_create_streams_events_and_records_session() {
     let mock_server = MockServer::start().await;
 
+    // The mock requires content-type: application/json and stream=true in the upstream
+    // POST, which proves that the WS bridge injects these regardless of what the client
+    // sends (the client deliberately sends stream=false below).
     Mock::given(method("POST"))
         .and(path("/responses"))
+        .and(header("content-type", "application/json"))
+        .and(body_partial_json(serde_json::json!({"stream": true})))
         .respond_with(ResponseTemplate::new(200).set_body_string(upstream_sse_body()))
         .expect(1)
         .mount(&mock_server)
@@ -93,12 +98,14 @@ async fn ws_response_create_streams_events_and_records_session() {
     let url = format!("ws://127.0.0.1:{port}/v1/responses");
     let mut ws = ws_connect(&url).await;
 
-    // Send a response.create frame.
+    // Send a response.create frame with stream=false — the WS bridge must overwrite
+    // this to stream=true before forwarding to the upstream.
     let create = json!({
         "type": "response.create",
         "response": {
             "model": "gpt-5",
-            "input": "hello"
+            "input": "hello",
+            "stream": false
         }
     });
     ws.send(Message::Text(create.to_string().into()))
@@ -279,5 +286,78 @@ async fn ws_sends_error_frame_for_unsupported_event_type() {
         "expected code=unsupported_event_type; got {value}"
     );
 
+    // Unsupported event types must never reach the upstream; the mock server
+    // must have received zero requests.
+    let reqs = mock_server.received_requests().await.unwrap();
+    assert!(
+        reqs.is_empty(),
+        "unsupported event type must not hit upstream; got {} requests",
+        reqs.len()
+    );
+
+    ws.close(None).await.ok();
+}
+
+#[tokio::test]
+async fn ws_works_on_compat_responses_path_and_post_coexists() {
+    // Exercises the /responses compat route (no /v1 prefix).
+    // Pins that the dual-route wiring (GET=WS upgrade, POST=HTTP) is registered
+    // for the compat path.  The POST-coexistence half is omitted because the
+    // mock server returns an SSE body that the non-streaming passthrough handler
+    // cannot parse as JSON; a dedicated HTTP-only test covers POST separately.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(upstream_sse_body()))
+        .mount(&mock_server)
+        .await;
+
+    let store = Arc::new(InMemorySessionStore::new());
+
+    let config = OpenAIConfig {
+        api_key: "test-api-key".to_string(),
+        base_url: mock_server.uri(),
+        organization: None,
+        client_config: Default::default(),
+        custom_headers: None,
+        request_body_config: None,
+        response_body_config: None,
+        codex_auth: None,
+        switch_notification_message: None,
+    };
+    let connector = Arc::new(OpenAIConnector::new(config).await.unwrap());
+    let port = spawn_passthrough(connector, store).await;
+
+    // WS upgrade to /responses (no /v1 prefix) — pins compat-route wiring.
+    let url = format!("ws://127.0.0.1:{port}/responses");
+    let mut ws = ws_connect(&url).await;
+
+    let create = json!({
+        "type": "response.create",
+        "response": { "model": "gpt-5", "input": "hi" }
+    });
+    ws.send(Message::Text(create.to_string().into()))
+        .await
+        .unwrap();
+
+    let mut got_completed = false;
+    while let Some(frame) = ws.next().await {
+        let msg = frame.unwrap();
+        let text = match msg {
+            Message::Text(t) => t.to_string(),
+            Message::Close(_) => break,
+            _ => continue,
+        };
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        if value.get("type").and_then(|v| v.as_str()) == Some("response.completed") {
+            got_completed = true;
+            break;
+        }
+    }
+    assert!(
+        got_completed,
+        "WS on /responses compat route must drive full pipeline"
+    );
     ws.close(None).await.ok();
 }

--- a/crates/lunaroute-integration-tests/tests/responses_websocket.rs
+++ b/crates/lunaroute-integration-tests/tests/responses_websocket.rs
@@ -1,0 +1,283 @@
+//! Integration tests for OpenAI Responses API WebSocket ingress.
+//!
+//! Verifies:
+//! 1. A `response.create` frame drives the HTTP pipeline and streams events back.
+//! 2. Session events (Started, RequestRecorded, Completed) are recorded.
+//! 3. Multiple `response.create` frames on one connection run sequentially.
+//! 4. An unsupported event type returns a structured error frame.
+
+mod common;
+
+use common::InMemorySessionStore;
+use futures::{SinkExt, StreamExt};
+use lunaroute_egress::openai::{OpenAIConfig, OpenAIConnector};
+use lunaroute_session::SessionEvent;
+use serde_json::json;
+use std::sync::Arc;
+use tokio_tungstenite::tungstenite::Message;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Bind the passthrough router to a random localhost port and return the port.
+/// The task runs `axum::serve` on a `tokio::net::TcpListener`.
+async fn spawn_passthrough(
+    connector: Arc<OpenAIConnector>,
+    store: Arc<InMemorySessionStore>,
+) -> u16 {
+    let app = lunaroute_ingress::openai::passthrough_router(
+        connector,
+        None,
+        None,
+        Some(store),
+        15,
+        true,
+        None,
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    // Give the server a beat to start accepting.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    port
+}
+
+/// Build a minimal Responses API SSE body: created → output_text.delta → completed.
+fn upstream_sse_body() -> String {
+    [
+        r#"{"type":"response.created","response":{"id":"resp_1","model":"gpt-5"}}"#,
+        r#"{"type":"response.output_text.delta","delta":"hi"}"#,
+        r#"{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":5,"output_tokens":1,"total_tokens":6}}}"#,
+    ]
+    .iter()
+    .map(|e| format!("data: {e}\n\n"))
+    .collect::<String>()
+}
+
+/// Build and connect a WebSocket client to the given URL, returning the stream/sink.
+async fn ws_connect(
+    url: &str,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    let (ws, _resp) = tokio_tungstenite::connect_async(url).await.unwrap();
+    ws
+}
+
+#[tokio::test]
+async fn ws_response_create_streams_events_and_records_session() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(upstream_sse_body()))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let store = Arc::new(InMemorySessionStore::new());
+
+    let config = OpenAIConfig {
+        api_key: "test-api-key".to_string(),
+        base_url: mock_server.uri(),
+        organization: None,
+        client_config: Default::default(),
+        custom_headers: None,
+        request_body_config: None,
+        response_body_config: None,
+        codex_auth: None,
+        switch_notification_message: None,
+    };
+    let connector = Arc::new(OpenAIConnector::new(config).await.unwrap());
+
+    let port = spawn_passthrough(connector, store.clone()).await;
+    let url = format!("ws://127.0.0.1:{port}/v1/responses");
+    let mut ws = ws_connect(&url).await;
+
+    // Send a response.create frame.
+    let create = json!({
+        "type": "response.create",
+        "response": {
+            "model": "gpt-5",
+            "input": "hello"
+        }
+    });
+    ws.send(Message::Text(create.to_string().into()))
+        .await
+        .unwrap();
+
+    // Collect frames until `response.completed` arrives.
+    let mut seen_types: Vec<String> = Vec::new();
+    while let Some(frame) = ws.next().await {
+        let msg = frame.unwrap();
+        let text = match msg {
+            Message::Text(t) => t.to_string(),
+            Message::Close(_) => break,
+            _ => continue,
+        };
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let ty = value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        seen_types.push(ty.clone());
+        if ty == "response.completed" {
+            break;
+        }
+    }
+
+    assert_eq!(
+        seen_types,
+        vec![
+            "response.created",
+            "response.output_text.delta",
+            "response.completed"
+        ],
+        "unexpected event order; got {seen_types:?}"
+    );
+
+    // Give async session writers a moment to flush.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let events = store.get_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, SessionEvent::Started { .. })),
+        "expected Started event; got {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, SessionEvent::RequestRecorded { .. })),
+        "expected RequestRecorded event; got {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, SessionEvent::Completed { .. })),
+        "expected Completed event; got {events:?}"
+    );
+
+    ws.close(None).await.ok();
+}
+
+#[tokio::test]
+async fn ws_runs_two_response_creates_sequentially_on_one_connection() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(upstream_sse_body()))
+        .expect(2)
+        .mount(&mock_server)
+        .await;
+
+    let store = Arc::new(InMemorySessionStore::new());
+
+    let config = OpenAIConfig {
+        api_key: "test-api-key".to_string(),
+        base_url: mock_server.uri(),
+        organization: None,
+        client_config: Default::default(),
+        custom_headers: None,
+        request_body_config: None,
+        response_body_config: None,
+        codex_auth: None,
+        switch_notification_message: None,
+    };
+    let connector = Arc::new(OpenAIConnector::new(config).await.unwrap());
+
+    let port = spawn_passthrough(connector, store.clone()).await;
+    let url = format!("ws://127.0.0.1:{port}/v1/responses");
+    let mut ws = ws_connect(&url).await;
+
+    for _ in 0..2 {
+        let create = json!({
+            "type": "response.create",
+            "response": { "model": "gpt-5", "input": "hi" }
+        });
+        ws.send(Message::Text(create.to_string().into()))
+            .await
+            .unwrap();
+
+        // Drain frames until `response.completed`.
+        loop {
+            let msg = ws.next().await.unwrap().unwrap();
+            let text = match msg {
+                Message::Text(t) => t.to_string(),
+                Message::Close(_) => {
+                    panic!("server closed connection unexpectedly mid-test");
+                }
+                _ => continue,
+            };
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            if value.get("type").and_then(|v| v.as_str()) == Some("response.completed") {
+                break;
+            }
+        }
+    }
+
+    ws.close(None).await.ok();
+
+    // Upstream must have received exactly 2 POSTs; wiremock's `.expect(2)` asserts
+    // this implicitly on drop when the mock_server is dropped at end of scope.
+}
+
+#[tokio::test]
+async fn ws_sends_error_frame_for_unsupported_event_type() {
+    let mock_server = MockServer::start().await;
+
+    // Mount a mock but we don't expect it to be called (response.cancel is rejected
+    // before hitting the upstream).
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(upstream_sse_body()))
+        .mount(&mock_server)
+        .await;
+
+    let config = OpenAIConfig {
+        api_key: "test-api-key".to_string(),
+        base_url: mock_server.uri(),
+        organization: None,
+        client_config: Default::default(),
+        custom_headers: None,
+        request_body_config: None,
+        response_body_config: None,
+        codex_auth: None,
+        switch_notification_message: None,
+    };
+    let connector = Arc::new(OpenAIConnector::new(config).await.unwrap());
+    let store = Arc::new(InMemorySessionStore::new());
+    let port = spawn_passthrough(connector, store).await;
+
+    let url = format!("ws://127.0.0.1:{port}/v1/responses");
+    let mut ws = ws_connect(&url).await;
+
+    // Send an unsupported event type.
+    ws.send(Message::Text(r#"{"type":"response.cancel"}"#.into()))
+        .await
+        .unwrap();
+
+    let msg = ws.next().await.unwrap().unwrap();
+    let text = match msg {
+        Message::Text(t) => t.to_string(),
+        other => panic!("expected text frame, got {other:?}"),
+    };
+    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        value.get("type").and_then(|v| v.as_str()),
+        Some("error"),
+        "expected type=error; got {value}"
+    );
+    assert_eq!(
+        value
+            .get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|v| v.as_str()),
+        Some("unsupported_event_type"),
+        "expected code=unsupported_event_type; got {value}"
+    );
+
+    ws.close(None).await.ok();
+}

--- a/crates/lunaroute-integration-tests/tests/switch_notification_integration.rs
+++ b/crates/lunaroute-integration-tests/tests/switch_notification_integration.rs
@@ -332,8 +332,10 @@ async fn test_cross_dialect_notification() {
         .await;
 
     // Create OpenAI provider
-    let mut client_config = HttpClientConfig::default();
-    client_config.max_retries = 0; // Disable retries for predictable mock expectations
+    let client_config = HttpClientConfig {
+        max_retries: 0, // Disable retries for predictable mock expectations
+        ..Default::default()
+    };
 
     let openai_config = OpenAIConfig {
         api_key: "test-key".to_string(),
@@ -580,8 +582,10 @@ async fn test_notification_idempotency_cascading_fallbacks() {
         .await;
 
     // Create providers
-    let mut client_config = HttpClientConfig::default();
-    client_config.max_retries = 0; // Disable retries for predictable mock expectations
+    let client_config = HttpClientConfig {
+        max_retries: 0, // Disable retries for predictable mock expectations
+        ..Default::default()
+    };
 
     let primary_config = OpenAIConfig {
         api_key: "test-key".to_string(),

--- a/crates/lunaroute-observability/src/metrics.rs
+++ b/crates/lunaroute-observability/src/metrics.rs
@@ -130,6 +130,16 @@ pub struct Metrics {
     /// Pool configuration settings (max_idle_per_host, idle_timeout_secs, etc.)
     /// NOTE: This CAN be populated at startup - instrumentation TODO
     pub pool_config: GaugeVec,
+
+    // WebSocket metrics
+    /// Total WebSocket connections accepted, by endpoint
+    pub ws_connections_opened: CounterVec,
+    /// Total WebSocket connections closed, by endpoint
+    pub ws_connections_closed: CounterVec,
+    /// Duration of WebSocket connections in seconds, by endpoint
+    pub ws_connection_duration_seconds: HistogramVec,
+    /// Total WebSocket frames, by endpoint, direction (client|server), and type
+    pub ws_frames_total: CounterVec,
 }
 
 impl Metrics {
@@ -417,6 +427,37 @@ impl Metrics {
             &["provider", "setting"],
         )?;
 
+        // WebSocket metrics
+        let ws_connections_opened = CounterVec::new(
+            Opts::new(
+                "lunaroute_ws_connections_opened_total",
+                "Total WebSocket connections accepted, by endpoint",
+            ),
+            &["endpoint"],
+        )?;
+        let ws_connections_closed = CounterVec::new(
+            Opts::new(
+                "lunaroute_ws_connections_closed_total",
+                "Total WebSocket connections closed, by endpoint",
+            ),
+            &["endpoint"],
+        )?;
+        let ws_connection_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "lunaroute_ws_connection_duration_seconds",
+                "Duration of WebSocket connections in seconds, by endpoint",
+            )
+            .buckets(vec![1.0, 10.0, 60.0, 300.0, 900.0, 1800.0, 3600.0]),
+            &["endpoint"],
+        )?;
+        let ws_frames_total = CounterVec::new(
+            Opts::new(
+                "lunaroute_ws_frames_total",
+                "Total WebSocket frames, by endpoint, direction (client|server), and type",
+            ),
+            &["endpoint", "direction", "type"],
+        )?;
+
         // Register all metrics
         registry.register(Box::new(requests_total.clone()))?;
         registry.register(Box::new(requests_success.clone()))?;
@@ -451,6 +492,10 @@ impl Metrics {
         registry.register(Box::new(pool_connections_idle.clone()))?;
         registry.register(Box::new(pool_connection_lifetime_seconds.clone()))?;
         registry.register(Box::new(pool_config.clone()))?;
+        registry.register(Box::new(ws_connections_opened.clone()))?;
+        registry.register(Box::new(ws_connections_closed.clone()))?;
+        registry.register(Box::new(ws_connection_duration_seconds.clone()))?;
+        registry.register(Box::new(ws_frames_total.clone()))?;
 
         Ok(Self {
             registry: Arc::new(registry),
@@ -487,6 +532,10 @@ impl Metrics {
             pool_connections_idle,
             pool_connection_lifetime_seconds,
             pool_config,
+            ws_connections_opened,
+            ws_connections_closed,
+            ws_connection_duration_seconds,
+            ws_frames_total,
         })
     }
 
@@ -799,6 +848,30 @@ impl Metrics {
             "tcp_keepalive_secs",
             tcp_keepalive_secs as f64,
         );
+    }
+
+    /// Record a new WebSocket connection opening
+    pub fn record_ws_connection_opened(&self, endpoint: &str) {
+        self.ws_connections_opened
+            .with_label_values(&[endpoint])
+            .inc();
+    }
+
+    /// Record a WebSocket connection closing, with duration observation
+    pub fn record_ws_connection_closed(&self, endpoint: &str, duration_secs: f64) {
+        self.ws_connections_closed
+            .with_label_values(&[endpoint])
+            .inc();
+        self.ws_connection_duration_seconds
+            .with_label_values(&[endpoint])
+            .observe(duration_secs);
+    }
+
+    /// Record a WebSocket frame (by direction and type)
+    pub fn record_ws_frame(&self, endpoint: &str, direction: &str, frame_type: &str) {
+        self.ws_frames_total
+            .with_label_values(&[endpoint, direction, frame_type])
+            .inc();
     }
 }
 

--- a/crates/lunaroute-routing/src/notification.rs
+++ b/crates/lunaroute-routing/src/notification.rs
@@ -144,10 +144,10 @@ mod tests {
     }
 
     #[test]
-    fn test_switch_reason_clone() {
+    fn test_switch_reason_copy() {
         let reason = SwitchReason::RateLimit;
-        let cloned = reason.clone();
-        assert_eq!(reason.to_generic_message(), cloned.to_generic_message());
+        let copied = reason;
+        assert_eq!(reason.to_generic_message(), copied.to_generic_message());
     }
 
     #[test]

--- a/crates/lunaroute-routing/src/router.rs
+++ b/crates/lunaroute-routing/src/router.rs
@@ -261,7 +261,7 @@ impl RouteTable {
     /// Create a route table with the given rules
     pub fn with_rules(mut rules: Vec<RoutingRule>) -> Self {
         // Sort rules by priority (highest first)
-        rules.sort_by(|a, b| b.priority.cmp(&a.priority));
+        rules.sort_by_key(|r| std::cmp::Reverse(r.priority));
         Self { rules }
     }
 
@@ -269,7 +269,7 @@ impl RouteTable {
     pub fn add_rule(&mut self, rule: RoutingRule) {
         self.rules.push(rule);
         // Re-sort after adding
-        self.rules.sort_by(|a, b| b.priority.cmp(&a.priority));
+        self.rules.sort_by_key(|r| std::cmp::Reverse(r.priority));
     }
 
     /// Find a matching route for the given request and context

--- a/docs/plans/2026-04-16-codex-ws-smoke.md
+++ b/docs/plans/2026-04-16-codex-ws-smoke.md
@@ -22,7 +22,7 @@ Verify the end-to-end Codex → lunaroute → OpenAI path using the WS transport
 5. Optionally, to watch WS lifecycle logs, run the server in the foreground with debug logging instead of `eval $(lunaroute-server env)`:
 
    ```bash
-   RUST_LOG=lunaroute_ingress=debug lunaroute-server serve
+   LUNAROUTE_LOG_LEVEL=debug lunaroute-server serve
    ```
 
    You should see `WS session started` then `WS session ended` for each request.

--- a/docs/plans/2026-04-16-codex-ws-smoke.md
+++ b/docs/plans/2026-04-16-codex-ws-smoke.md
@@ -14,9 +14,15 @@ Verify the end-to-end Codex → lunaroute → OpenAI path using the WS transport
    supports_websockets = true
    ```
 
-3. Run a trivial Codex command, e.g. `codex "print hello world in rust"`.
+3. Run a trivial Codex command, e.g. `codex exec "print hello world in rust"`.
 4. Open the lunaroute UI at `http://127.0.0.1:8082` — verify:
    - The session shows up.
    - Tokens are non-zero.
    - Response text matches what Codex displayed.
-5. Optionally, watch logs: `lunaroute-server logs -f` — should see `WS session started` then `WS session ended` for the request.
+5. Optionally, to watch WS lifecycle logs, run the server in the foreground with debug logging instead of `eval $(lunaroute-server env)`:
+
+   ```bash
+   RUST_LOG=lunaroute_ingress=debug lunaroute-server serve
+   ```
+
+   You should see `WS session started` then `WS session ended` for each request.

--- a/docs/plans/2026-04-16-codex-ws-smoke.md
+++ b/docs/plans/2026-04-16-codex-ws-smoke.md
@@ -1,0 +1,22 @@
+# Codex CLI WebSocket Smoke Test
+
+Verify the end-to-end Codex → lunaroute → OpenAI path using the WS transport.
+
+1. Start lunaroute: `eval $(lunaroute-server env)`.
+2. Edit `~/.codex/config.toml`:
+
+   ```toml
+   [model_providers.openai]
+   name = "OpenAI"
+   base_url = "http://127.0.0.1:8081/v1"
+   env_key = "OPENAI_API_KEY"
+   wire_api = "responses"
+   supports_websockets = true
+   ```
+
+3. Run a trivial Codex command, e.g. `codex "print hello world in rust"`.
+4. Open the lunaroute UI at `http://127.0.0.1:8082` — verify:
+   - The session shows up.
+   - Tokens are non-zero.
+   - Response text matches what Codex displayed.
+5. Optionally, watch logs: `lunaroute-server logs -f` — should see `WS session started` then `WS session ended` for the request.

--- a/docs/superpowers/plans/2026-04-16-codex-websocket-responses.md
+++ b/docs/superpowers/plans/2026-04-16-codex-websocket-responses.md
@@ -1,0 +1,1321 @@
+# Codex CLI WebSocket Responses API — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept OpenAI Responses API traffic over WebSocket on `/v1/responses` and `/responses`, so Codex CLI with `supports_websockets = true` works against lunaroute with full feature parity (session recording, LUNAROUTE markers, metrics, provider registry).
+
+**Architecture:** WebSocket terminator. Accept the upgrade, parse each `response.create` frame, drive the existing HTTP Responses pipeline upstream (with `stream=true`), translate SSE events back to WS text frames. No new egress code; reuses `OpenAIConnector` and the existing streaming pipeline via a small refactor that extracts the SSE-generating core into a reusable function.
+
+**Tech Stack:** Rust, axum 0.8 (`ws` feature already enabled), `tokio-tungstenite` (already transitive via axum; added as dev-dep for integration tests), `eventsource-stream`, existing lunaroute infrastructure.
+
+**Spec:** [docs/superpowers/specs/2026-04-16-codex-websocket-responses-design.md](../specs/2026-04-16-codex-websocket-responses-design.md)
+
+---
+
+## File Map
+
+- **Create:**
+  - `crates/lunaroute-ingress/src/responses_ws.rs` — new module with frame parser, WS handler, read loop.
+  - `crates/lunaroute-integration-tests/tests/responses_websocket.rs` — integration test driving a real TCP server with `tokio-tungstenite`.
+- **Modify:**
+  - `crates/lunaroute-ingress/src/openai.rs` — extract `responses_sse_stream` helper from `responses_passthrough`; add `SseEvent` type; expose whatever `responses_ws.rs` needs from `OpenAIPassthroughState`.
+  - `crates/lunaroute-ingress/src/lib.rs` — `pub mod responses_ws;`.
+  - `crates/lunaroute-observability/src/metrics.rs` — add WS counters/histograms.
+  - `Cargo.toml` (workspace) — add `tokio-tungstenite = "0.28"` to `[workspace.dependencies]`.
+  - `crates/lunaroute-integration-tests/Cargo.toml` — pull `tokio-tungstenite` into `[dev-dependencies]`.
+
+All other existing behavior is unchanged. HTTP `/responses` passthrough stays byte-identical.
+
+---
+
+## Task 1: Baseline + add `tokio-tungstenite` to workspace
+
+**Files:**
+- Modify: `Cargo.toml` (workspace root)
+- Modify: `crates/lunaroute-integration-tests/Cargo.toml`
+
+- [ ] **Step 1: Run full test suite to confirm clean baseline**
+
+Run: `cargo test --workspace --no-fail-fast 2>&1 | tail -40`
+Expected: all tests pass. If anything is red on `main`, stop and fix before proceeding.
+
+- [ ] **Step 2: Add `tokio-tungstenite` to workspace deps**
+
+Edit `Cargo.toml` (root), add in the `[workspace.dependencies]` block near the other HTTP libs (after `eventsource-stream = "0.2"`):
+
+```toml
+tokio-tungstenite = "0.28"
+```
+
+- [ ] **Step 3: Pull into integration tests as a dev-dep**
+
+Edit `crates/lunaroute-integration-tests/Cargo.toml`, add to `[dev-dependencies]`:
+
+```toml
+tokio-tungstenite = { workspace = true }
+```
+
+- [ ] **Step 4: Verify workspace still builds**
+
+Run: `cargo check --workspace`
+Expected: clean build, no new warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml crates/lunaroute-integration-tests/Cargo.toml
+git commit -m "chore: add tokio-tungstenite for WS integration tests"
+```
+
+---
+
+## Task 2: Extract `SseEvent` + `responses_sse_stream` core (pure refactor)
+
+**Goal:** Lift the streaming pipeline out of `responses_passthrough` into a function the WS handler can call. Zero behavior change to the HTTP path.
+
+**Files:**
+- Modify: `crates/lunaroute-ingress/src/openai.rs:~890-1700`
+
+- [ ] **Step 1: Add `SseEvent` struct near top of `openai.rs`**
+
+Insert right after the existing `MAX_COLLECTED_EVENTS` constant (around line 34):
+
+```rust
+/// A single SSE event yielded by the shared responses pipeline.
+///
+/// Both the HTTP handler (which re-wraps in `axum::response::sse::Event`)
+/// and the WebSocket handler (which sends the `data` payload as a text frame)
+/// consume this.
+#[derive(Debug, Clone)]
+pub(crate) struct SseEvent {
+    pub event: String,
+    pub data: String,
+}
+```
+
+- [ ] **Step 2: Locate the streaming branch of `responses_passthrough`**
+
+Open `crates/lunaroute-ingress/src/openai.rs` and find `async fn responses_passthrough` (around line 904). Within it, find the `if is_streaming { ... }` block (starts around line 1213). Note the end of the block — it's where the function returns `Ok(Sse::new(mapped_stream).keep_alive(sse_keepalive).into_response())`.
+
+This whole block becomes the body of the new helper, with one change: instead of returning an axum SSE response, return a `BoxStream<Result<SseEvent, IngressError>>`.
+
+- [ ] **Step 3: Introduce the new helper `responses_sse_stream`**
+
+Add this new function directly above `async fn responses_passthrough`:
+
+```rust
+use futures::stream::BoxStream;
+
+/// Drive the upstream `/responses` streaming pipeline and return a stream of
+/// SSE events. Shared by HTTP `responses_passthrough` and the WebSocket
+/// handler in `crate::responses_ws`.
+///
+/// Performs: header filtering, LUNAROUTE marker detection, session recording
+/// (Started / RequestRecorded / StatsUpdated / ToolCallRecorded / Completed),
+/// upstream call via `OpenAIConnector::stream_passthrough_to_endpoint_bytes`,
+/// SSE parsing, and metric extraction. Identical side effects to the original
+/// streaming branch — just no axum wrapping.
+pub(crate) async fn responses_sse_stream(
+    state: Arc<OpenAIPassthroughState>,
+    headers: axum::http::HeaderMap,
+    body: axum::body::Bytes,
+) -> Result<BoxStream<'static, Result<SseEvent, IngressError>>, IngressError> {
+    // Body copied verbatim from the streaming branch of `responses_passthrough`
+    // below, with the following minimal changes:
+    //   1. The final `Ok(Sse::new(mapped_stream).keep_alive(...).into_response())`
+    //      is replaced with `Ok(mapped_stream.boxed())`.
+    //   2. The `filter_map` closure emits `SseEvent { event, data }` instead of
+    //      `axum::response::sse::Event::default().data(event.data).event(event.event)`.
+    //   3. The stream error branch emits
+    //      `SseEvent { event: "error".into(), data: format!("error: {e}") }`
+    //      instead of an axum `Event::default().data(...)`.
+    //
+    // All header filtering, session ID extraction, session event emission,
+    // marker handling, tool-call mapping, and stats accumulation stays exactly
+    // as in the original streaming branch.
+    //
+    // NOTE: The non-streaming branch of `responses_passthrough` is NOT moved
+    // here — WS always streams. The HTTP handler keeps its non-streaming path.
+
+    todo!("Implement by moving streaming-branch code from responses_passthrough")
+}
+```
+
+This stub will be filled in in the next step.
+
+- [ ] **Step 4: Move the streaming-branch code into the helper**
+
+In the same file, cut the entire body of the `if is_streaming { ... }` block from `responses_passthrough` (from the line `if is_streaming {` through the return of `Ok(Sse::new(mapped_stream)...into_response())`). Paste it into `responses_sse_stream`, replacing the `todo!(...)`. Apply the three minimal changes from the comment:
+
+At the `filter_map` emission site, change:
+```rust
+match result {
+    Ok(event) => Some(
+        Ok::<_, eventsource_stream::EventStreamError<std::io::Error>>(
+            Event::default().data(event.data).event(event.event),
+        ),
+    ),
+    Err(e) => Some(
+        Ok::<_, eventsource_stream::EventStreamError<std::io::Error>>(
+            Event::default().data(format!("error: {}", e)),
+        ),
+    ),
+}
+```
+to:
+```rust
+match result {
+    Ok(event) => Some(Ok::<SseEvent, IngressError>(SseEvent {
+        event: event.event,
+        data: event.data,
+    })),
+    Err(e) => Some(Ok::<SseEvent, IngressError>(SseEvent {
+        event: "error".into(),
+        data: format!("error: {e}"),
+    })),
+}
+```
+
+At the function tail, change:
+```rust
+Ok(Sse::new(mapped_stream)
+    .keep_alive(sse_keepalive)
+    .into_response())
+```
+to:
+```rust
+use futures::StreamExt as _;
+Ok(mapped_stream.boxed())
+```
+
+Remove the now-unused `sse_keepalive_interval` / `sse_keepalive_enabled_flag` clones from the helper — they were only used to build the axum `KeepAlive`.
+
+- [ ] **Step 5: Replace streaming branch in `responses_passthrough`**
+
+Back in `responses_passthrough`, where the `if is_streaming { ... }` block used to be, write:
+
+```rust
+if is_streaming {
+    let sse_keepalive_interval = state.sse_keepalive_interval_secs;
+    let sse_keepalive_enabled_flag = state.sse_keepalive_enabled;
+
+    let event_stream = responses_sse_stream(state.clone(), headers.clone(), body.clone()).await?;
+
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use futures::StreamExt as _;
+    let axum_stream = event_stream.map(|result| match result {
+        Ok(ev) => Ok::<_, std::convert::Infallible>(
+            Event::default().data(ev.data).event(ev.event),
+        ),
+        Err(e) => Ok::<_, std::convert::Infallible>(
+            Event::default().data(format!("error: {e}")),
+        ),
+    });
+
+    let keepalive = if sse_keepalive_enabled_flag {
+        KeepAlive::new().interval(std::time::Duration::from_secs(sse_keepalive_interval))
+    } else {
+        KeepAlive::new().interval(std::time::Duration::from_secs(86400))
+    };
+
+    return Ok(Sse::new(axum_stream).keep_alive(keepalive).into_response());
+}
+```
+
+The non-streaming branch below is untouched.
+
+- [ ] **Step 6: Fix imports; resolve compile**
+
+Run: `cargo check -p lunaroute-ingress`
+Expected: compiles clean. If there are `use` errors, the helper needs the same imports the streaming branch used (`futures::StreamExt`, `eventsource_stream::EventStream`, `lunaroute_session::*`, etc.) — copy the relevant `use` statements over. Do NOT shadow or reorder anything in `responses_passthrough`.
+
+- [ ] **Step 7: Run the passthrough streaming recording integration tests**
+
+Run:
+```bash
+cargo test -p lunaroute_integration_tests --test passthrough_streaming_recording -- --nocapture 2>&1 | tail -30
+```
+Expected: all 4 tests pass. This is the tightest check that the refactor preserved behavior (session events + SSE frames).
+
+- [ ] **Step 8: Run the full workspace test suite**
+
+Run: `cargo test --workspace --no-fail-fast 2>&1 | tail -30`
+Expected: all tests pass. Nothing regressed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/lunaroute-ingress/src/openai.rs
+git commit -m "refactor: extract responses_sse_stream from responses_passthrough
+
+Pure code motion: streaming pipeline for /v1/responses now lives in a
+reusable helper returning Stream<SseEvent>. HTTP handler wraps it in
+axum Sse as before. No behavior change; all existing integration tests
+pass unchanged. Prepares for WebSocket ingress on /responses."
+```
+
+---
+
+## Task 3: Frame parser + `responses_ws.rs` skeleton
+
+**Goal:** Land the new module with a frame parser and unit tests. No handler yet, no routing yet.
+
+**Files:**
+- Create: `crates/lunaroute-ingress/src/responses_ws.rs`
+- Modify: `crates/lunaroute-ingress/src/lib.rs`
+
+- [ ] **Step 1: Create the module file**
+
+Create `crates/lunaroute-ingress/src/responses_ws.rs` with:
+
+```rust
+//! WebSocket ingress for OpenAI's Responses API.
+//!
+//! Codex CLI (with `supports_websockets = true`) opens a WebSocket to
+//! `/v1/responses`. This module accepts the upgrade, parses `response.create`
+//! frames, and drives the same HTTP streaming pipeline used by
+//! `openai::responses_passthrough` via `openai::responses_sse_stream`.
+//!
+//! See `docs/superpowers/specs/2026-04-16-codex-websocket-responses-design.md`.
+
+use serde::Deserialize;
+
+/// Parsed client-to-server WebSocket frame.
+#[derive(Debug, Clone)]
+pub(crate) enum ClientEvent {
+    /// `{"type": "response.create", "response": {...}}` — create a response.
+    /// The inner `response` object is the usual Responses API create payload.
+    ResponseCreate { response: serde_json::Value },
+}
+
+/// Error returned by `parse_client_frame`.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FrameError {
+    #[error("malformed JSON: {0}")]
+    MalformedJson(#[from] serde_json::Error),
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+    #[error("unsupported event type: {0}")]
+    UnsupportedType(String),
+}
+
+/// Parse a client text frame into a `ClientEvent`.
+///
+/// Accepted shape: `{"type": "response.create", "response": {...}}` with
+/// `response` being any JSON object (the Responses API create body). Anything
+/// else returns a `FrameError` the caller maps to a structured error frame.
+pub(crate) fn parse_client_frame(text: &str) -> Result<ClientEvent, FrameError> {
+    #[derive(Deserialize)]
+    struct Envelope {
+        r#type: String,
+        #[serde(default)]
+        response: Option<serde_json::Value>,
+    }
+
+    let envelope: Envelope = serde_json::from_str(text)?;
+    match envelope.r#type.as_str() {
+        "response.create" => {
+            let response = envelope
+                .response
+                .ok_or(FrameError::MissingField("response"))?;
+            if !response.is_object() {
+                return Err(FrameError::MissingField("response (must be object)"));
+            }
+            Ok(ClientEvent::ResponseCreate { response })
+        }
+        other => Err(FrameError::UnsupportedType(other.to_string())),
+    }
+}
+
+/// Build a server-side error frame payload in the Responses API event shape.
+pub(crate) fn error_frame(code: &str, message: &str) -> String {
+    serde_json::json!({
+        "type": "error",
+        "error": {
+            "code": code,
+            "message": message,
+        }
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_response_create() {
+        let text = r#"{"type":"response.create","response":{"model":"gpt-5","input":"hi"}}"#;
+        let ev = parse_client_frame(text).unwrap();
+        match ev {
+            ClientEvent::ResponseCreate { response } => {
+                assert_eq!(response.get("model").and_then(|v| v.as_str()), Some("gpt-5"));
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_type() {
+        let text = r#"{"type":"response.cancel"}"#;
+        let err = parse_client_frame(text).unwrap_err();
+        assert!(matches!(err, FrameError::UnsupportedType(ref t) if t == "response.cancel"));
+    }
+
+    #[test]
+    fn rejects_missing_response_field() {
+        let text = r#"{"type":"response.create"}"#;
+        let err = parse_client_frame(text).unwrap_err();
+        assert!(matches!(err, FrameError::MissingField("response")));
+    }
+
+    #[test]
+    fn rejects_non_object_response() {
+        let text = r#"{"type":"response.create","response":"not-an-object"}"#;
+        let err = parse_client_frame(text).unwrap_err();
+        assert!(matches!(err, FrameError::MissingField(_)));
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let err = parse_client_frame("{not json").unwrap_err();
+        assert!(matches!(err, FrameError::MalformedJson(_)));
+    }
+
+    #[test]
+    fn error_frame_has_expected_shape() {
+        let frame = error_frame("unsupported_event_type", "nope");
+        let value: serde_json::Value = serde_json::from_str(&frame).unwrap();
+        assert_eq!(value.get("type").and_then(|v| v.as_str()), Some("error"));
+        assert_eq!(
+            value
+                .get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|v| v.as_str()),
+            Some("unsupported_event_type")
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Wire module into `lib.rs`**
+
+Edit `crates/lunaroute-ingress/src/lib.rs`, add alongside the other `pub mod` declarations:
+
+```rust
+pub mod responses_ws;
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `cargo test -p lunaroute-ingress responses_ws:: -- --nocapture`
+Expected: 6 tests pass (`parses_response_create`, `rejects_unknown_type`, `rejects_missing_response_field`, `rejects_non_object_response`, `rejects_malformed_json`, `error_frame_has_expected_shape`).
+
+- [ ] **Step 4: Run the full workspace test suite**
+
+Run: `cargo test --workspace --no-fail-fast 2>&1 | tail -20`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/lunaroute-ingress/src/responses_ws.rs crates/lunaroute-ingress/src/lib.rs
+git commit -m "feat: frame parser for Responses API WebSocket ingress"
+```
+
+---
+
+## Task 4: WebSocket handler + read loop
+
+**Goal:** Accept the upgrade, run a read loop that parses `response.create`, drives `responses_sse_stream`, and forwards events as WS text frames. Not yet wired into the router — that's Task 5.
+
+**Files:**
+- Modify: `crates/lunaroute-ingress/src/responses_ws.rs`
+- Modify: `crates/lunaroute-ingress/src/openai.rs` (may need to expose `OpenAIPassthroughState` or its fields — check in Step 1)
+
+- [ ] **Step 1: Make `OpenAIPassthroughState` and `responses_sse_stream` reachable from sibling module**
+
+Open `crates/lunaroute-ingress/src/openai.rs`. Find `struct OpenAIPassthroughState` (near line 1920ish). If it is not `pub(crate)` or public, change it to `pub(crate) struct OpenAIPassthroughState`. Do the same with `fn responses_sse_stream` if it isn't already (it was defined `pub(crate)` in Task 2).
+
+Run: `cargo check -p lunaroute-ingress`
+Expected: clean.
+
+- [ ] **Step 2: Append WS handler code to `responses_ws.rs`**
+
+Append to `crates/lunaroute-ingress/src/responses_ws.rs` (before the `#[cfg(test)]` module):
+
+```rust
+use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::http::HeaderMap;
+use axum::response::Response;
+use futures::StreamExt as _;
+use std::sync::Arc;
+
+use crate::openai::{OpenAIPassthroughState, SseEvent, responses_sse_stream};
+
+/// Terminal Responses API event types — receiving one of these means the
+/// current response is finished and the read loop may accept the next
+/// `response.create` frame on the same connection.
+const TERMINAL_EVENTS: &[&str] = &[
+    "response.completed",
+    "response.failed",
+    "response.incomplete",
+    "response.cancelled",
+];
+
+/// axum handler: accept the WebSocket upgrade on `/responses` or
+/// `/v1/responses` and spawn a per-connection session.
+pub async fn responses_ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<OpenAIPassthroughState>>,
+    headers: HeaderMap,
+) -> Response {
+    tracing::debug!("Responses API WebSocket upgrade");
+    ws.on_upgrade(move |socket| run_ws_session(socket, state, headers))
+}
+
+/// Own the socket for a single WebSocket connection. Reads client frames,
+/// runs each `response.create` through the shared SSE pipeline, sends each
+/// resulting event back as a WS text frame. Sequential by construction — we
+/// await each stream to completion before the next `recv`.
+async fn run_ws_session(
+    mut socket: WebSocket,
+    state: Arc<OpenAIPassthroughState>,
+    upgrade_headers: HeaderMap,
+) {
+    tracing::debug!("WS session started");
+
+    while let Some(msg) = socket.recv().await {
+        let msg = match msg {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!("WS recv error: {e}");
+                break;
+            }
+        };
+
+        match msg {
+            Message::Text(text) => {
+                if let Err(e) =
+                    handle_client_text(&mut socket, &state, &upgrade_headers, text.as_ref()).await
+                {
+                    tracing::warn!("WS text handling error: {e}");
+                    // Connection stays open unless the error indicates a send failure
+                    // (in which case the next recv will fail too).
+                }
+            }
+            Message::Close(_) => {
+                tracing::debug!("WS client closed");
+                break;
+            }
+            Message::Ping(_) | Message::Pong(_) => {
+                // axum handles ping/pong automatically; nothing to do.
+            }
+            Message::Binary(_) => {
+                let _ = send_error(
+                    &mut socket,
+                    "unsupported_frame_type",
+                    "binary frames are not supported",
+                )
+                .await;
+            }
+        }
+    }
+
+    tracing::debug!("WS session ended");
+}
+
+/// Dispatch one client text frame: parse, run the pipeline, forward events.
+async fn handle_client_text(
+    socket: &mut WebSocket,
+    state: &Arc<OpenAIPassthroughState>,
+    upgrade_headers: &HeaderMap,
+    text: &str,
+) -> Result<(), axum::Error> {
+    let event = match parse_client_frame(text) {
+        Ok(e) => e,
+        Err(FrameError::MalformedJson(e)) => {
+            return send_error(socket, "malformed_json", &e.to_string()).await;
+        }
+        Err(FrameError::MissingField(f)) => {
+            return send_error(socket, "invalid_request", &format!("missing field: {f}"))
+                .await;
+        }
+        Err(FrameError::UnsupportedType(t)) => {
+            return send_error(
+                socket,
+                "unsupported_event_type",
+                &format!("unsupported event type: {t}"),
+            )
+            .await;
+        }
+    };
+
+    match event {
+        ClientEvent::ResponseCreate { mut response } => {
+            // Force stream=true: upstream HTTP needs it for streaming.
+            if response.get("stream").is_none() {
+                response["stream"] = serde_json::Value::Bool(true);
+            }
+            let body_bytes = match serde_json::to_vec(&response) {
+                Ok(b) => axum::body::Bytes::from(b),
+                Err(e) => {
+                    return send_error(socket, "internal_error", &e.to_string()).await;
+                }
+            };
+
+            let stream = match responses_sse_stream(
+                state.clone(),
+                upgrade_headers.clone(),
+                body_bytes,
+            )
+            .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    return send_error(socket, "upstream_error", &e.to_string()).await;
+                }
+            };
+
+            forward_stream(socket, stream).await
+        }
+    }
+}
+
+/// Forward a stream of `SseEvent`s as WebSocket text frames until a terminal
+/// event is seen or the stream ends.
+async fn forward_stream(
+    socket: &mut WebSocket,
+    mut stream: futures::stream::BoxStream<'static, Result<SseEvent, crate::IngressError>>,
+) -> Result<(), axum::Error> {
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(ev) => {
+                // Send just the `data` payload — the event name is already
+                // embedded in the JSON's `type` field per the Responses WS spec.
+                socket.send(Message::Text(ev.data.clone().into())).await?;
+                if is_terminal(&ev) {
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                return send_error(socket, "stream_error", &e.to_string()).await;
+            }
+        }
+    }
+    // Stream ended with no terminal event — emit a synthetic error so the
+    // client doesn't hang waiting.
+    send_error(
+        socket,
+        "stream_ended",
+        "upstream stream ended without a terminal event",
+    )
+    .await
+}
+
+fn is_terminal(ev: &SseEvent) -> bool {
+    if TERMINAL_EVENTS.contains(&ev.event.as_str()) {
+        return true;
+    }
+    // Fall back to inspecting the JSON `type` field inside `data`.
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&ev.data)
+        && let Some(t) = value.get("type").and_then(|v| v.as_str())
+    {
+        return TERMINAL_EVENTS.contains(&t);
+    }
+    false
+}
+
+async fn send_error(
+    socket: &mut WebSocket,
+    code: &str,
+    message: &str,
+) -> Result<(), axum::Error> {
+    socket
+        .send(Message::Text(error_frame(code, message).into()))
+        .await
+}
+```
+
+- [ ] **Step 3: Re-export the handler from the crate for external use**
+
+Open `crates/lunaroute-ingress/src/lib.rs`. Below the existing `pub use` lines, add:
+
+```rust
+pub use responses_ws::responses_ws_handler;
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `cargo check -p lunaroute-ingress 2>&1 | tail -20`
+Expected: clean. If `OpenAIPassthroughState` is still private and fails — double back to Step 1 and make it `pub(crate)`. If `crate::IngressError` import path fails, use `crate::types::IngressError` instead.
+
+- [ ] **Step 5: Run existing tests to confirm nothing broke**
+
+Run: `cargo test --workspace --no-fail-fast 2>&1 | tail -20`
+Expected: all pass (handler is not yet wired to any route, so this is pure "compiles and doesn't regress" check).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/lunaroute-ingress/src/responses_ws.rs crates/lunaroute-ingress/src/lib.rs crates/lunaroute-ingress/src/openai.rs
+git commit -m "feat: WebSocket handler + read loop for Responses API ingress"
+```
+
+---
+
+## Task 5: Wire WS handler into `passthrough_router`
+
+**Goal:** Codex CLI can now hit `ws://host/responses` or `ws://host/v1/responses` and the handler runs.
+
+**Files:**
+- Modify: `crates/lunaroute-ingress/src/openai.rs:~1953-1958` (in `passthrough_router`)
+
+- [ ] **Step 1: Update route definitions to accept GET (upgrade) alongside POST**
+
+In `passthrough_router` (around line 1953), change:
+
+```rust
+.route("/v1/chat/completions", post(chat_completions_passthrough))
+.route("/v1/responses", post(responses_passthrough))
+.route("/responses", post(responses_passthrough)) // For Codex compatibility (base_url without /v1)
+.route("/v1/models", axum::routing::get(models_passthrough))
+.route("/models", axum::routing::get(models_passthrough)) // For Codex compatibility (base_url without /v1)
+```
+
+to:
+
+```rust
+use axum::routing::get;
+.route("/v1/chat/completions", post(chat_completions_passthrough))
+.route(
+    "/v1/responses",
+    post(responses_passthrough).get(crate::responses_ws::responses_ws_handler),
+)
+.route(
+    "/responses",
+    post(responses_passthrough).get(crate::responses_ws::responses_ws_handler),
+)
+.route("/v1/models", get(models_passthrough))
+.route("/models", get(models_passthrough))
+```
+
+(The `use axum::routing::get;` goes near the other `use axum::routing::post;` at the top of the function body.)
+
+- [ ] **Step 2: Compile**
+
+Run: `cargo check -p lunaroute-ingress 2>&1 | tail -10`
+Expected: clean.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `cargo test --workspace --no-fail-fast 2>&1 | tail -20`
+Expected: all pass. HTTP `/responses` behavior is preserved because POST still dispatches to `responses_passthrough`; the WS handler is only reached on a GET-with-upgrade.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/lunaroute-ingress/src/openai.rs
+git commit -m "feat: wire WS handler into /responses routes"
+```
+
+---
+
+## Task 6: Integration test — full WS roundtrip with session recording
+
+**Goal:** Prove the whole chain works end-to-end against a mocked upstream.
+
+**Files:**
+- Create: `crates/lunaroute-integration-tests/tests/responses_websocket.rs`
+
+- [ ] **Step 1: Write the integration test file**
+
+Create `crates/lunaroute-integration-tests/tests/responses_websocket.rs`:
+
+```rust
+//! Integration tests for OpenAI Responses API WebSocket ingress.
+//!
+//! Verifies:
+//! 1. A `response.create` frame drives the HTTP pipeline and streams events back.
+//! 2. Session events (Started, RequestRecorded, Completed) are recorded.
+//! 3. Multiple `response.create` frames on one connection run sequentially.
+//! 4. Upstream errors are translated into structured error frames.
+
+mod common;
+
+use common::InMemorySessionStore;
+use futures::{SinkExt, StreamExt};
+use lunaroute_egress::openai::{OpenAIConfig, OpenAIConnector};
+use lunaroute_session::SessionEvent;
+use serde_json::json;
+use std::sync::Arc;
+use tokio_tungstenite::tungstenite::Message;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Bind the passthrough router to a random localhost port and return the port +
+/// server task handle. The task runs `axum::serve` on a `tokio::net::TcpListener`.
+async fn spawn_passthrough(
+    connector: Arc<OpenAIConnector>,
+    store: Arc<InMemorySessionStore>,
+) -> u16 {
+    let app = lunaroute_ingress::openai::passthrough_router(
+        connector, None, None, Some(store), 15, true, None,
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    // Give the server a beat to start accepting.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    port
+}
+
+fn upstream_sse_body() -> String {
+    // Minimal Responses API stream: created → output_text.delta → completed.
+    // Each event is `data: <json>\n\n` per SSE.
+    [
+        r#"{"type":"response.created","response":{"id":"resp_1","model":"gpt-5"}}"#,
+        r#"{"type":"response.output_text.delta","delta":"hi"}"#,
+        r#"{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":5,"output_tokens":1,"total_tokens":6}}}"#,
+    ]
+    .iter()
+    .map(|e| format!("data: {e}\n\n"))
+    .collect::<String>()
+}
+
+#[tokio::test]
+async fn ws_response_create_streams_events_and_records_session() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(upstream_sse_body()))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let store = Arc::new(InMemorySessionStore::new());
+
+    let config = OpenAIConfig {
+        api_key: "test-api-key".to_string(),
+        base_url: mock_server.uri(),
+        organization: None,
+        client_config: Default::default(),
+        custom_headers: None,
+        request_body_config: None,
+        response_body_config: None,
+        codex_auth: None,
+        switch_notification_message: None,
+    };
+    let connector = Arc::new(OpenAIConnector::new(config).await.unwrap());
+
+    let port = spawn_passthrough(connector, store.clone()).await;
+
+    // Connect WebSocket to the /v1/responses endpoint with an Authorization header.
+    let url = format!("ws://127.0.0.1:{port}/v1/responses");
+    let request = tokio_tungstenite::tungstenite::client::IntoClientRequest::into_client_request(
+        url.as_str(),
+    )
+    .unwrap();
+    // Inject Authorization header — mimic what Codex CLI sends at upgrade.
+    let mut request = request;
+    request
+        .headers_mut()
+        .insert("authorization", "Bearer test-api-key".parse().unwrap());
+
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(request).await.unwrap();
+
+    // Send a response.create.
+    let create = json!({
+        "type": "response.create",
+        "response": {
+            "model": "gpt-5",
+            "input": "hello"
+        }
+    });
+    ws.send(Message::Text(create.to_string().into()))
+        .await
+        .unwrap();
+
+    // Collect frames until the `response.completed` arrives.
+    let mut seen_types: Vec<String> = Vec::new();
+    while let Some(frame) = ws.next().await {
+        let msg = frame.unwrap();
+        let text = match msg {
+            Message::Text(t) => t.to_string(),
+            Message::Close(_) => break,
+            _ => continue,
+        };
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let ty = value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        seen_types.push(ty.clone());
+        if ty == "response.completed" {
+            break;
+        }
+    }
+
+    assert_eq!(
+        seen_types,
+        vec![
+            "response.created",
+            "response.output_text.delta",
+            "response.completed"
+        ],
+        "unexpected event order; got {seen_types:?}"
+    );
+
+    // Give async session writers a moment to flush.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let events = store.get_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, SessionEvent::Started { .. })),
+        "expected Started event; got {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, SessionEvent::RequestRecorded { .. })),
+        "expected RequestRecorded event"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, SessionEvent::Completed { .. })),
+        "expected Completed event"
+    );
+
+    ws.close(None).await.ok();
+}
+
+#[tokio::test]
+async fn ws_runs_two_response_creates_sequentially_on_one_connection() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(upstream_sse_body()))
+        .expect(2)
+        .mount(&mock_server)
+        .await;
+
+    let store = Arc::new(InMemorySessionStore::new());
+
+    let config = OpenAIConfig {
+        api_key: "test-api-key".to_string(),
+        base_url: mock_server.uri(),
+        organization: None,
+        client_config: Default::default(),
+        custom_headers: None,
+        request_body_config: None,
+        response_body_config: None,
+        codex_auth: None,
+        switch_notification_message: None,
+    };
+    let connector = Arc::new(OpenAIConnector::new(config).await.unwrap());
+
+    let port = spawn_passthrough(connector, store.clone()).await;
+    let url = format!("ws://127.0.0.1:{port}/v1/responses");
+    let mut request = tokio_tungstenite::tungstenite::client::IntoClientRequest::into_client_request(
+        url.as_str(),
+    )
+    .unwrap();
+    request
+        .headers_mut()
+        .insert("authorization", "Bearer test-api-key".parse().unwrap());
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(request).await.unwrap();
+
+    for _ in 0..2 {
+        let create = json!({
+            "type": "response.create",
+            "response": { "model": "gpt-5", "input": "hi" }
+        });
+        ws.send(Message::Text(create.to_string().into())).await.unwrap();
+
+        loop {
+            let msg = ws.next().await.unwrap().unwrap();
+            let Message::Text(t) = msg else { continue };
+            let value: serde_json::Value = serde_json::from_str(&t).unwrap();
+            if value.get("type").and_then(|v| v.as_str()) == Some("response.completed") {
+                break;
+            }
+        }
+    }
+
+    ws.close(None).await.ok();
+
+    // Upstream should have seen exactly 2 POSTs; wiremock's `.expect(2)` above
+    // asserts this implicitly on drop.
+}
+
+#[tokio::test]
+async fn ws_sends_error_frame_for_unsupported_event_type() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(upstream_sse_body()))
+        .mount(&mock_server)
+        .await;
+
+    let config = OpenAIConfig {
+        api_key: "test-api-key".to_string(),
+        base_url: mock_server.uri(),
+        organization: None,
+        client_config: Default::default(),
+        custom_headers: None,
+        request_body_config: None,
+        response_body_config: None,
+        codex_auth: None,
+        switch_notification_message: None,
+    };
+    let connector = Arc::new(OpenAIConnector::new(config).await.unwrap());
+    let store = Arc::new(InMemorySessionStore::new());
+    let port = spawn_passthrough(connector, store).await;
+
+    let url = format!("ws://127.0.0.1:{port}/v1/responses");
+    let (mut ws, _) = tokio_tungstenite::connect_async(url).await.unwrap();
+
+    ws.send(Message::Text(r#"{"type":"response.cancel"}"#.into()))
+        .await
+        .unwrap();
+
+    let msg = ws.next().await.unwrap().unwrap();
+    let Message::Text(text) = msg else {
+        panic!("expected text frame, got {msg:?}")
+    };
+    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(value.get("type").and_then(|v| v.as_str()), Some("error"));
+    assert_eq!(
+        value
+            .get("error")
+            .and_then(|e| e.get("code"))
+            .and_then(|v| v.as_str()),
+        Some("unsupported_event_type")
+    );
+
+    ws.close(None).await.ok();
+}
+```
+
+- [ ] **Step 2: Run the new integration tests**
+
+Run:
+```bash
+cargo test -p lunaroute_integration_tests --test responses_websocket -- --nocapture 2>&1 | tail -40
+```
+Expected: all 3 tests pass.
+
+- [ ] **Step 3: Run the full workspace test suite**
+
+Run: `cargo test --workspace --no-fail-fast 2>&1 | tail -20`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/lunaroute-integration-tests/tests/responses_websocket.rs
+git commit -m "test: end-to-end WS Responses API integration tests"
+```
+
+---
+
+## Task 7: WS metrics
+
+**Goal:** Emit connection + frame counters so operators can see WS traffic in Prometheus.
+
+**Files:**
+- Modify: `crates/lunaroute-observability/src/metrics.rs`
+- Modify: `crates/lunaroute-ingress/src/responses_ws.rs`
+
+- [ ] **Step 1: Add new metric fields and registration in `Metrics`**
+
+In `crates/lunaroute-observability/src/metrics.rs`, find the `Metrics` struct definition. Add four new fields (alongside the existing counters/histograms):
+
+```rust
+pub ws_connections_opened: CounterVec,
+pub ws_connections_closed: CounterVec,
+pub ws_connection_duration_seconds: HistogramVec,
+pub ws_frames_total: CounterVec,
+```
+
+In `impl Metrics { pub fn new(...) -> Result<Self, prometheus::Error> { ... }`, register them. Follow the pattern of the existing `fallbacks_total` and `request_duration_seconds` registration. Use these names and labels:
+
+```rust
+let ws_connections_opened = CounterVec::new(
+    Opts::new(
+        "lunaroute_ws_connections_opened_total",
+        "Total WebSocket connections accepted, by endpoint",
+    ),
+    &["endpoint"],
+)?;
+let ws_connections_closed = CounterVec::new(
+    Opts::new(
+        "lunaroute_ws_connections_closed_total",
+        "Total WebSocket connections closed, by endpoint",
+    ),
+    &["endpoint"],
+)?;
+let ws_connection_duration_seconds = HistogramVec::new(
+    HistogramOpts::new(
+        "lunaroute_ws_connection_duration_seconds",
+        "Duration of WebSocket connections in seconds, by endpoint",
+    )
+    .buckets(vec![1.0, 10.0, 60.0, 300.0, 900.0, 1800.0, 3600.0]),
+    &["endpoint"],
+)?;
+let ws_frames_total = CounterVec::new(
+    Opts::new(
+        "lunaroute_ws_frames_total",
+        "Total WebSocket frames, by endpoint, direction (client|server), and type",
+    ),
+    &["endpoint", "direction", "type"],
+)?;
+
+registry.register(Box::new(ws_connections_opened.clone()))?;
+registry.register(Box::new(ws_connections_closed.clone()))?;
+registry.register(Box::new(ws_connection_duration_seconds.clone()))?;
+registry.register(Box::new(ws_frames_total.clone()))?;
+```
+
+And include them in the final `Metrics { ... }` construction. Run:
+
+```bash
+cargo check -p lunaroute-observability
+```
+Expected: clean.
+
+- [ ] **Step 2: Add helper methods on `Metrics`**
+
+In the same file, inside `impl Metrics`:
+
+```rust
+pub fn record_ws_connection_opened(&self, endpoint: &str) {
+    self.ws_connections_opened
+        .with_label_values(&[endpoint])
+        .inc();
+}
+
+pub fn record_ws_connection_closed(&self, endpoint: &str, duration_secs: f64) {
+    self.ws_connections_closed
+        .with_label_values(&[endpoint])
+        .inc();
+    self.ws_connection_duration_seconds
+        .with_label_values(&[endpoint])
+        .observe(duration_secs);
+}
+
+pub fn record_ws_frame(&self, endpoint: &str, direction: &str, frame_type: &str) {
+    self.ws_frames_total
+        .with_label_values(&[endpoint, direction, frame_type])
+        .inc();
+}
+```
+
+Run: `cargo check -p lunaroute-observability`
+Expected: clean.
+
+- [ ] **Step 3: Thread `state` into `forward_stream` and instrument both functions**
+
+In `crates/lunaroute-ingress/src/responses_ws.rs`, replace `run_ws_session`, `handle_client_text`, and `forward_stream` with the instrumented versions below. All three change together so the `state` reference flows through cleanly.
+
+Replace `run_ws_session`:
+
+```rust
+async fn run_ws_session(
+    mut socket: WebSocket,
+    state: Arc<OpenAIPassthroughState>,
+    upgrade_headers: HeaderMap,
+) {
+    const ENDPOINT: &str = "responses";
+    let started = std::time::Instant::now();
+    if let Some(metrics) = &state.metrics {
+        metrics.record_ws_connection_opened(ENDPOINT);
+    }
+
+    tracing::debug!("WS session started");
+
+    while let Some(msg) = socket.recv().await {
+        let msg = match msg {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!("WS recv error: {e}");
+                break;
+            }
+        };
+
+        match msg {
+            Message::Text(text) => {
+                if let Some(metrics) = &state.metrics {
+                    metrics.record_ws_frame(ENDPOINT, "client", "text");
+                }
+                if let Err(e) =
+                    handle_client_text(&mut socket, &state, &upgrade_headers, text.as_ref()).await
+                {
+                    tracing::warn!("WS text handling error: {e}");
+                }
+            }
+            Message::Close(_) => {
+                tracing::debug!("WS client closed");
+                break;
+            }
+            Message::Ping(_) | Message::Pong(_) => {}
+            Message::Binary(_) => {
+                let _ = send_error(
+                    &mut socket,
+                    "unsupported_frame_type",
+                    "binary frames are not supported",
+                )
+                .await;
+            }
+        }
+    }
+
+    if let Some(metrics) = &state.metrics {
+        metrics.record_ws_connection_closed(ENDPOINT, started.elapsed().as_secs_f64());
+    }
+    tracing::debug!("WS session ended after {:?}", started.elapsed());
+}
+```
+
+Update `handle_client_text` — change the final `forward_stream(socket, stream).await` call site to pass `state`:
+
+```rust
+forward_stream(socket, state, stream).await
+```
+
+Replace `forward_stream` with:
+
+```rust
+async fn forward_stream(
+    socket: &mut WebSocket,
+    state: &Arc<OpenAIPassthroughState>,
+    mut stream: futures::stream::BoxStream<'static, Result<SseEvent, crate::IngressError>>,
+) -> Result<(), axum::Error> {
+    const ENDPOINT: &str = "responses";
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(ev) => {
+                if let Some(metrics) = &state.metrics {
+                    let ty = if ev.event.is_empty() { "message" } else { ev.event.as_str() };
+                    metrics.record_ws_frame(ENDPOINT, "server", ty);
+                }
+                socket.send(Message::Text(ev.data.clone().into())).await?;
+                if is_terminal(&ev) {
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                return send_error(socket, "stream_error", &e.to_string()).await;
+            }
+        }
+    }
+    send_error(
+        socket,
+        "stream_ended",
+        "upstream stream ended without a terminal event",
+    )
+    .await
+}
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `cargo check -p lunaroute-ingress`
+Expected: clean.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cargo test --workspace --no-fail-fast 2>&1 | tail -20`
+Expected: all pass — the integration tests run without a `Metrics` instance (the `None` passed to `passthrough_router`), so metric code paths are skipped and don't affect behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/lunaroute-observability/src/metrics.rs crates/lunaroute-ingress/src/responses_ws.rs
+git commit -m "feat: prometheus metrics for WS Responses ingress"
+```
+
+---
+
+## Task 8: Documentation + smoke test
+
+**Goal:** Leave a trail so the next person can verify Codex CLI actually works.
+
+**Files:**
+- Modify: `README.md` (add short note under the Codex CLI section)
+- Create: `docs/plans/2026-04-16-codex-ws-smoke.md` — manual smoke-test runbook
+
+- [ ] **Step 1: README tweak**
+
+In `README.md`, find the "OpenAI Codex CLI" bullet (around line 529). Replace it with:
+
+```markdown
+- ✅ **OpenAI Codex CLI** - Automatic auth.json integration. Supports both HTTP and WebSocket transports — set `supports_websockets = true` in `~/.codex/config.toml` to use the WS path (lunaroute terminates the WS and drives the HTTP pipeline; session recording, markers, and metrics all work the same).
+```
+
+- [ ] **Step 2: Smoke-test runbook**
+
+Create `docs/plans/2026-04-16-codex-ws-smoke.md`:
+
+```markdown
+# Codex CLI WebSocket Smoke Test
+
+Verify the end-to-end Codex → lunaroute → OpenAI path using the WS transport.
+
+1. Start lunaroute: `eval $(lunaroute-server env)`.
+2. Edit `~/.codex/config.toml`:
+
+   ```toml
+   [model_providers.openai]
+   name = "OpenAI"
+   base_url = "http://127.0.0.1:8081/v1"
+   env_key = "OPENAI_API_KEY"
+   wire_api = "responses"
+   supports_websockets = true
+   ```
+
+3. Run a trivial Codex command, e.g. `codex "print hello world in rust"`.
+4. Open the lunaroute UI at `http://127.0.0.1:8082` — verify:
+   - The session shows up.
+   - Tokens are non-zero.
+   - Response text matches what Codex displayed.
+5. Optionally, watch logs: `lunaroute-server logs -f` — should see `WS session started` then `WS session ended` for the request.
+```
+
+- [ ] **Step 3: Run full test suite one last time**
+
+Run: `cargo test --workspace --no-fail-fast 2>&1 | tail -10`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/plans/2026-04-16-codex-ws-smoke.md
+git commit -m "docs: Codex WS smoke test runbook + README note"
+```
+
+---
+
+## Final Verification
+
+- [ ] **All tasks complete, all tests green**
+
+Run: `cargo test --workspace --no-fail-fast 2>&1 | tail -10`
+Expected: all pass.
+
+- [ ] **Manual smoke test** (if you have Codex CLI installed)
+
+Follow `docs/plans/2026-04-16-codex-ws-smoke.md`.
+
+- [ ] **Review diff summary**
+
+Run: `git log --oneline main..HEAD`
+Expected: 8 commits, one per task.

--- a/docs/superpowers/specs/2026-04-16-codex-websocket-responses-design.md
+++ b/docs/superpowers/specs/2026-04-16-codex-websocket-responses-design.md
@@ -1,0 +1,214 @@
+# Codex CLI WebSocket Responses API Support
+
+**Date:** 2026-04-16
+**Status:** Draft
+**Related:** [LUNAROUTE Marker-Based Provider Routing](2026-04-03-lunaroute-marker-routing-design.md), [Cross-Dialect Marker Routing](2026-04-03-cross-dialect-marker-routing-design.md)
+
+## Problem
+
+Codex CLI now speaks OpenAI's Responses API over WebSocket in addition to HTTP+SSE. When its provider is configured with `supports_websockets = true` (the default for the built-in `openai` provider in recent versions), it opens a WebSocket to `{openai_base_url}/responses` instead of issuing HTTP POSTs. Lunaroute only exposes the HTTP handler on `/responses` and `/v1/responses`, so the upgrade handshake fails and Codex either errors out or stalls.
+
+The goal is to let Codex CLI point at lunaroute with the WebSocket transport enabled and have everything (session recording, LUNAROUTE markers, metrics, provider registry, `codex_auth`) work exactly as it does for HTTP.
+
+## Solution
+
+Accept the incoming WebSocket as a thin terminator and drive the existing HTTP Responses pipeline for every `response.create` message. Translate the upstream SSE stream back into WebSocket text frames that mirror the Responses streaming event model. No new egress code, no new WebSocket client — `reqwest` and the existing `OpenAIConnector` keep doing the work.
+
+## Scope
+
+**In scope:**
+
+- WebSocket upgrade on `GET /v1/responses` and `GET /responses` (mirroring the current HTTP route pair).
+- Full feature parity with the HTTP `/responses` passthrough: LUNAROUTE markers (same-dialect only), session recording, metrics, provider registry, `codex_auth`, header filtering, session ID extraction.
+- Sequential in-flight semantics per connection (one response in flight at a time — matches the upstream contract Codex expects).
+- Structured error frames on upstream or marker errors; connection stays open so Codex can send the next `response.create`.
+
+**Out of scope:**
+
+- True WebSocket→WebSocket transparent proxying (no WS client in egress).
+- Local `previous_response_id` cache for `store=false` fast continuation. Lunaroute relies on `store=true` upstream; the `store=false` case loses WS-local cache benefit and this is documented.
+- Cross-dialect marker routing from WebSocket ingress (same restriction as HTTP `/responses` today). A marker pointing at an Anthropic provider returns the same "cross-dialect requires normalized mode" error as HTTP.
+- 60-minute hard cap on client ↔ lunaroute connection. Upstream enforces its own limits on each HTTP call; there's no reason to impose one on the client hop.
+
+## Wire Protocol (what Codex speaks)
+
+Reference: OpenAI Responses API WebSocket Mode — `wss://api.openai.com/v1/responses`.
+
+- **Upgrade:** standard HTTP GET with `Upgrade: websocket`. Client sends `Authorization: Bearer …` and other OpenAI headers on the upgrade request.
+- **Client → server frames:** JSON text frames shaped like
+  ```json
+  { "type": "response.create", "response": { /* Responses API create body */ } }
+  ```
+  plus optional `previous_response_id` and `input` fields inside `response`.
+- **Server → client frames:** JSON text frames matching the Responses SSE event model (`response.created`, `response.output_text.delta`, `response.completed`, `response.error`, `response.failed`, …), one event per frame.
+- **Transport-only fields** (`stream`, `background`) are ignored; the WS is inherently streaming and foreground.
+- **Sequential:** a single connection runs one response at a time. The client is expected to wait for a terminal event (`response.completed` / `response.failed` / error frame) before sending the next `response.create`. Lunaroute enforces this by awaiting completion on the read-loop.
+
+## Data Flow
+
+```
+Codex CLI
+  → WS upgrade on /v1/responses (or /responses)
+    → axum WebSocket handler (new)
+      loop:
+        → recv text frame (response.create)
+          → extract response body + merge with upgrade-time headers
+          → set stream = true internally
+          → call process_responses_request(state, headers, body):
+            ← marker detection → provider override (same-dialect only)
+            ← session recording (Started, RequestRecorded)
+            ← upstream call via OpenAIConnector
+            ← SSE parsing (eventsource_stream)
+            → yields Stream<SseEvent { event, data }>
+          → for each SseEvent: send Message::Text(data) as WS frame
+          → on terminal event (see "Terminal events" below): record ResponseCompleted, return to recv
+      on client close: cancel in-flight upstream stream, close WS cleanly
+```
+
+## Code Layout
+
+1. **Extract shared core.** Refactor the body of `responses_passthrough()` in `crates/lunaroute-ingress/src/openai.rs` into a reusable function:
+   ```rust
+   pub(crate) async fn process_responses_request(
+       state: Arc<OpenAIPassthroughState>,
+       headers: HeaderMap,
+       body: Bytes,
+   ) -> Result<ResponseEventStream, IngressError>;
+   ```
+   where `ResponseEventStream` is `impl Stream<Item = Result<SseEvent, StreamError>>` and each `SseEvent` carries `{ event: String, data: String }` — exactly what `eventsource_stream` already produces inside the current HTTP handler. This matches the existing pipeline (which also parses SSE to typed events for metrics extraction before re-emitting), so there's no new parse/serialize overhead.
+
+   - **HTTP handler** wraps each `SseEvent` in `axum::response::sse::Event::default().event(&e.event).data(&e.data)` — behavior is byte-equivalent to today.
+   - **WS handler** sends `Message::Text(e.data)` — just the JSON data payload. The Responses WS wire format puts the event name inside the JSON's `type` field, so the SSE `event:` line is redundant and dropped.
+
+   The shared core handles: header filtering, session ID extraction, marker detection, upstream call via the configured `OpenAIConnector`, session recording (Started / RequestRecorded / ResponseCompleted), streaming metrics, and tool-call mapping. No logic changes — just code motion + a cleaner seam.
+
+2. **New WS handler.** Add `crates/lunaroute-ingress/src/responses_ws.rs` (~150–250 lines) with:
+   ```rust
+   pub async fn responses_ws_handler(
+       ws: WebSocketUpgrade,
+       State(state): State<Arc<OpenAIPassthroughState>>,
+       headers: HeaderMap,
+   ) -> Response;
+
+   async fn run_ws_session(
+       socket: WebSocket,
+       state: Arc<OpenAIPassthroughState>,
+       upgrade_headers: HeaderMap,
+   );
+   ```
+   `run_ws_session` owns the read loop, enforces sequential in-flight, and serializes events back to frames.
+
+3. **Wire up routes.** In `passthrough_router()`:
+   ```rust
+   .route("/v1/responses", post(responses_passthrough).get(responses_ws_handler))
+   .route("/responses",   post(responses_passthrough).get(responses_ws_handler))
+   ```
+   axum routes a GET-with-`Upgrade: websocket` header through `responses_ws_handler`; plain GETs will 400 from the handler (reject non-upgrade GETs).
+
+4. **Frame parsing.** Small helpers:
+   - `parse_client_frame(text: &str) -> Result<ClientEvent, FrameError>` — decode `response.create` (and reject unsupported types with a structured error frame back).
+   - `serialize_server_event(event: &ResponsesEvent) -> String` — already JSON, just `serde_json::to_string`.
+   - Non-text frames (binary, ping/pong) pass through axum's built-in keep-alive; we only act on `Message::Text`. Close frames end the session.
+
+## Behavior Details
+
+### Upgrade handshake
+
+- Handler accepts the upgrade and captures the `HeaderMap`. Headers are filtered through the existing `allowed_headers` list (`authorization`, `content-type`, `accept`, `user-agent`, `openai-beta`, `openai-organization`, `x-request-id`) plus session ID aliases (`session_id`, `session-id`, `x-session-id`).
+- If `Authorization` is missing, accept the upgrade anyway (matches HTTP behavior — the connector will surface the upstream 401). Log a warning, same as HTTP.
+
+### Request construction
+
+For each `response.create` frame:
+
+- Build a byte body from `event.response` (the inner create payload), force `"stream": true` if not already present (transport-only field — upstream HTTP needs it).
+- Use the upgrade-time filtered headers as the per-request header set. Codex only authenticates once per connection, so the Authorization from the upgrade carries through.
+
+### Session recording
+
+Identical to HTTP:
+
+- Per-connection: generate or reuse client-supplied session ID on the first frame; subsequent frames reuse it.
+- Per-frame: new `request_id`, emit `Started` + `RequestRecorded` on frame receipt, `ResponseCompleted` on terminal event.
+- Tool-result extraction from `input` array works unchanged (same code path).
+
+### Error handling
+
+| Situation | Lunaroute response | Connection |
+| --- | --- | --- |
+| Unsupported client frame type | Send `{ "type": "error", "error": { "code": "unsupported_event_type", "message": … } }` | Stay open |
+| Malformed JSON | Send structured error frame | Stay open |
+| Marker targets non-OpenAI provider | Send error frame (same message as HTTP cross-dialect rejection) | Stay open |
+| Upstream 4xx/5xx | Translate to `response.failed` / `response.error` event; preserve upstream body in `error` | Stay open |
+| Upstream timeout / network error | Send error frame | Stay open |
+| Client close | Cancel in-flight upstream stream, close WS | — |
+
+### Concurrency
+
+One task per WebSocket connection, running the read loop. No spawning per frame; the loop awaits the event stream to completion before the next `recv`. This gives us free sequential-in-flight semantics without queues or locks.
+
+### Terminal events
+
+A response is considered complete (read-loop can resume) when any of these arrive, or the upstream stream ends:
+
+- `response.completed` — normal success.
+- `response.failed` — model-side failure; payload includes the error.
+- `response.incomplete` — truncated (e.g., max_output_tokens). Treated as terminal; Codex handles it.
+- `response.cancelled` — if we later support `response.cancel` frames from the client.
+- Upstream stream end without any of the above → synthetic `response.error` frame is emitted, then the loop resumes.
+
+## Configuration
+
+No new config knobs. WS is enabled whenever passthrough mode is (it's a second transport on the same routes). If we need an opt-out later, a `passthrough.websocket_enabled: bool` in `config.yaml` defaulting to `true` is the shape.
+
+## Testing
+
+### Unit tests
+
+- `parse_client_frame` — accepts valid `response.create`, rejects unknown `type`, rejects malformed JSON.
+- `serialize_server_event` — round-trips each Responses event variant we care about.
+- Header filtering for the upgrade path (reuses existing helper, just proves the WS path hits it).
+
+### Integration tests
+
+New integration test in `crates/lunaroute-integration-tests`:
+
+- Spin up lunaroute with a wiremock upstream that serves `/v1/responses` SSE.
+- Open WS with `tokio-tungstenite` to `ws://localhost:<port>/v1/responses`.
+- Send a `response.create`; assert the WS frames received match the upstream SSE events.
+- Send a second `response.create` on the same connection; assert sequential processing.
+- Assert session events (Started, RequestRecorded, ResponseCompleted) are emitted for each frame.
+- Assert LUNAROUTE marker routes to an overridden provider (same-dialect) and the correct upstream is hit.
+- Assert error frame when the mock upstream returns 500.
+
+### Manual smoke
+
+Documented in the plan (not the spec): configure Codex CLI with `openai_base_url = "http://127.0.0.1:8081/v1"` and `supports_websockets = true`, confirm end-to-end completion + session shows in the UI.
+
+## Observability
+
+New metrics (via the existing `Metrics` facade):
+
+- `lunaroute_ws_connections_total{endpoint="responses"}` — counter.
+- `lunaroute_ws_connection_duration_seconds{endpoint="responses"}` — histogram.
+- `lunaroute_ws_frames_received_total{endpoint="responses", type="response.create"}` — counter.
+- `lunaroute_ws_frames_sent_total{endpoint="responses", terminal="true|false"}` — counter.
+
+Session events are the existing variants, so the UI needs no changes.
+
+## Migration / Compatibility
+
+- Existing HTTP `/responses` and `/v1/responses` behavior is unchanged. The refactor only moves code; the public handler signature is identical.
+- Clients that upgrade to WebSocket start getting frame responses; clients that POST keep getting SSE. Codex picks based on `supports_websockets`.
+- No config file changes required for existing users.
+
+## Risks
+
+- **Refactor regression.** Moving session-recording / marker / metrics code into `process_responses_request` is mechanical but large. Mitigated by the existing HTTP integration tests passing unchanged.
+- **Frame format drift.** OpenAI may add new client message types (`response.cancel`?). Initial scope rejects unknowns with a structured error; extend as Codex starts sending them.
+- **Back-pressure.** If upstream emits events faster than the WS can send (unlikely over localhost), the send-side buffering in `tokio-tungstenite` handles it; we don't need explicit flow control. Documented but not tested.
+- **`store=false` + fast continuation.** A user who explicitly sets `store=false` and relies on WS-local cache loses that optimization. Documented. True WS→WS is the escape hatch if this ever matters.
+
+## Open Questions
+
+None blocking. The `supports_websockets` default, exact connection cap, and cancel-frame support can evolve as Codex's behavior evolves; nothing here locks us in.


### PR DESCRIPTION
## Summary

- Accepts WebSocket upgrades on `GET /v1/responses` and `GET /responses` so Codex CLI with `supports_websockets = true` can connect.
- Thin "terminator" — parses `response.create` frames, drives the existing HTTP Responses pipeline upstream (`stream=true` always), and translates SSE events back as WS text frames. No new egress code.
- Full feature parity with the HTTP path: session recording, LUNAROUTE markers (same-dialect), metrics, provider registry, `codex_auth`, header filtering. Sequential in-flight per connection.

## What's in the diff

- Extracted `responses_sse_stream` from `responses_passthrough` — pure refactor, HTTP behavior unchanged
- New `responses_ws.rs` with frame parser, handler, read loop, terminal-event detection, structured error frames
- Wired GET + POST on both `/responses` and `/v1/responses`
- Prometheus metrics: `lunaroute_ws_connections_{opened,closed}_total`, `lunaroute_ws_connection_duration_seconds`, `lunaroute_ws_frames_total{endpoint,direction,type}` — labels use parsed Responses event types (`response.create`, `response.completed`, …), plus `malformed_json`/`unsupported_event_type`/`invalid_request`/`binary`/`error` for abnormal paths
- Integration tests proving: streaming + session recording, sequential in-flight, error frame for unsupported types, `/responses` compat path
- Unit tests for frame parser + `event_label` precedence
- README bullet + manual smoke-test runbook at \`docs/plans/2026-04-16-codex-ws-smoke.md\`

Design: \`docs/superpowers/specs/2026-04-16-codex-websocket-responses-design.md\`
Plan: \`docs/superpowers/plans/2026-04-16-codex-websocket-responses.md\`

## Test plan

- [x] \`cargo test --workspace --no-fail-fast\` — 937 pass, 0 fail, 43 ignored
- [x] \`cargo clippy -p lunaroute-ingress -p lunaroute-observability --all-targets -- -D warnings\` — clean
- [x] Each commit reviewed by roborev at max reasoning; tip commit clean at medium+
- [ ] Manual smoke test with Codex CLI per \`docs/plans/2026-04-16-codex-ws-smoke.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)