### PR TITLE
fix(egress): retry/rate-limit consistency — Anthropic 429 + saturating backoff

### DIFF
--- a/crates/lunaroute-egress/src/anthropic.rs
+++ b/crates/lunaroute-egress/src/anthropic.rs
@@ -1022,6 +1022,13 @@ impl AnthropicResponseExt for reqwest::Response {
     async fn handle_anthropic_response(self) -> Result<AnthropicResponse> {
         let status = self.status();
 
+        // Capture retry-after header before consuming response
+        let retry_after_secs = self
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(crate::parse_retry_after);
+
         if !status.is_success() {
             let status_code = status.as_u16();
             let body = self
@@ -1029,9 +1036,17 @@ impl AnthropicResponseExt for reqwest::Response {
                 .await
                 .unwrap_or_else(|_| "Unable to read error body".to_string());
 
-            return Err(EgressError::ProviderError {
-                status_code,
-                message: body,
+            return Err(if status_code == 429 {
+                debug!(
+                    retry_after_secs = ?retry_after_secs,
+                    "Anthropic rate limit exceeded"
+                );
+                EgressError::RateLimitExceeded { retry_after_secs }
+            } else {
+                EgressError::ProviderError {
+                    status_code,
+                    message: body,
+                }
             });
         }
 
@@ -1322,6 +1337,29 @@ mod tests {
                 }
             }
             _ => panic!("Expected Blocks content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_anthropic_response_429_returns_rate_limit_exceeded() {
+        use http::Response;
+        use reqwest::Response as ReqResponse;
+
+        // Build an http::Response with 429 + retry-after, convert to reqwest.
+        let http_resp = Response::builder()
+            .status(429)
+            .header("retry-after", "30")
+            .body(r#"{"type":"error","error":{"type":"rate_limit_error","message":"too many requests"}}"#.to_string())
+            .unwrap();
+        let resp: ReqResponse = http_resp.into();
+
+        let result = resp.handle_anthropic_response().await;
+
+        match result {
+            Err(EgressError::RateLimitExceeded { retry_after_secs }) => {
+                assert_eq!(retry_after_secs, Some(30));
+            }
+            other => panic!("expected RateLimitExceeded{{Some(30)}}, got {:?}", other),
         }
     }
 

--- a/crates/lunaroute-egress/src/client.rs
+++ b/crates/lunaroute-egress/src/client.rs
@@ -133,7 +133,12 @@ where
 
     for attempt in 0..=max_retries {
         if attempt > 0 {
-            let backoff_ms = 2u64.pow(attempt - 1) * 100; // Exponential backoff: 100ms, 200ms, 400ms
+            // Exponential backoff: 100ms, 200ms, 400ms ... saturating to avoid
+            // overflow for large max_retries (2u64.pow(64) would panic; checked_shl
+            // + saturating_mul caps instead). For realistic max_retries (3-10)
+            // values are identical to today.
+            let backoff_ms =
+                (1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100);
             debug!(
                 "Retrying request after {}ms (attempt {}/{})",
                 backoff_ms, attempt, max_retries
@@ -253,6 +258,62 @@ mod tests {
         .await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_backoff_does_not_overflow_for_large_max_retries_success_path() {
+        // max_retries=65 would overflow 2u64.pow(64) today (panic in debug).
+        // Saturating expression must not panic. Operation succeeds on first
+        // attempt, so no actual sleep — this checks the expression compiles
+        // and the fn doesn't panic on setup.
+        let result: Result<i32> = with_retry(65, || async { Ok(42) }).await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_backoff_does_not_overflow_for_large_max_retries_retry_path() {
+        // Force the retry path with a non-429 retryable error and max_retries=65.
+        // The backoff expression is evaluated on every retry; with the old
+        // 2u64.pow(attempt-1) this would panic at attempt=64. Saturating
+        // expression must not panic. Uses paused Tokio time plus explicit
+        // virtual-time advancement so the sleeps don't block real wall-clock.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_clone = attempts.clone();
+
+        let retry_task = tokio::spawn(async move {
+            with_retry(65, move || {
+                let a = attempts_clone.clone();
+                async move {
+                    a.fetch_add(1, Ordering::SeqCst);
+                    // Non-429 retryable error -> egress retries with exponential backoff.
+                    Err(EgressError::ProviderError {
+                        status_code: 500,
+                        message: "Internal error".to_string(),
+                    })
+                }
+            })
+            .await
+        });
+
+        for _ in 0..70 {
+            if retry_task.is_finished() {
+                break;
+            }
+            tokio::task::yield_now().await;
+            tokio::time::advance(Duration::from_millis(u64::MAX)).await;
+        }
+
+        assert!(
+            retry_task.is_finished(),
+            "retry task should finish without real-time sleeps"
+        );
+        let result: Result<i32> = retry_task.await.unwrap();
+        assert!(result.is_err());
+        // All 66 attempts (0..=65) ran without panicking.
+        assert_eq!(attempts.load(Ordering::SeqCst), 66);
     }
 
     #[test]

--- a/crates/lunaroute-server/src/config.rs
+++ b/crates/lunaroute-server/src/config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use tracing::warn;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -222,7 +223,19 @@ impl HttpClientSettings {
             tcp_keepalive_secs: self
                 .tcp_keepalive_secs
                 .unwrap_or(defaults.tcp_keepalive_secs),
-            max_retries: self.max_retries.unwrap_or(defaults.max_retries),
+            max_retries: {
+                let requested = self.max_retries.unwrap_or(defaults.max_retries);
+                if requested > 10 {
+                    warn!(
+                        requested = requested,
+                        clamped = 10,
+                        "max_retries exceeds safe ceiling; clamping to 10"
+                    );
+                    10
+                } else {
+                    requested
+                }
+            },
             enable_pool_metrics: self
                 .enable_pool_metrics
                 .unwrap_or(defaults.enable_pool_metrics),
@@ -824,6 +837,69 @@ mod tests {
         assert_eq!(config.tcp_keepalive_secs, 30);
         assert_eq!(config.max_retries, 5);
         assert!(!config.enable_pool_metrics);
+    }
+
+    #[test]
+    fn test_to_http_client_config_clamps_max_retries_to_10() {
+        let provider = ProviderSettings {
+            api_key: Some("test-key".to_string()),
+            base_url: None,
+            enabled: true,
+            http_client: Some(HttpClientSettings {
+                timeout_secs: Some(300),
+                connect_timeout_secs: Some(5),
+                pool_max_idle_per_host: Some(64),
+                pool_idle_timeout_secs: Some(120),
+                tcp_keepalive_secs: Some(30),
+                max_retries: Some(100),
+                enable_pool_metrics: Some(false),
+            }),
+            request_headers: None,
+            request_body: None,
+            response_body: None,
+            codex_auth: None,
+            provider_type: None,
+            model: None,
+        };
+        let config = provider
+            .http_client
+            .as_ref()
+            .unwrap()
+            .to_http_client_config();
+        assert_eq!(config.max_retries, 10, "max_retries must be clamped to 10");
+    }
+
+    #[test]
+    fn test_to_http_client_config_preserves_max_retries_under_10() {
+        let provider = ProviderSettings {
+            api_key: Some("test-key".to_string()),
+            base_url: None,
+            enabled: true,
+            http_client: Some(HttpClientSettings {
+                timeout_secs: Some(300),
+                connect_timeout_secs: Some(5),
+                pool_max_idle_per_host: Some(64),
+                pool_idle_timeout_secs: Some(120),
+                tcp_keepalive_secs: Some(30),
+                max_retries: Some(5),
+                enable_pool_metrics: Some(false),
+            }),
+            request_headers: None,
+            request_body: None,
+            response_body: None,
+            codex_auth: None,
+            provider_type: None,
+            model: None,
+        };
+        let config = provider
+            .http_client
+            .as_ref()
+            .unwrap()
+            .to_http_client_config();
+        assert_eq!(
+            config.max_retries, 5,
+            "max_retries under the ceiling is unchanged"
+        );
     }
 
     #[test]

--- a/docs/superpowers/plans/2026-07-02-retry-rate-limit-consistency.md
+++ b/docs/superpowers/plans/2026-07-02-retry-rate-limit-consistency.md
@@ -1,0 +1,525 @@
+# Retry / Rate-Limit Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make 429 handling consistent across providers (both return `RateLimitExceeded{retry_after}`; `with_retry` honors `retry-after`, capped at 60s/retry, bailing on longer), and fix the backoff overflow panic for large `max_retries`.
+
+**Architecture:** `handle_anthropic_response` mirrors the OpenAI handler: read `retry-after`, return `RateLimitExceeded` for 429. `with_retry` is restructured so the retry sleep is driven by the *previous attempt's error* (so `retry_after_secs` is available): `RateLimitExceeded{Some(ras)}` sleeps `ras*1000ms` if `ras <= 60` else bails; everything else uses saturating exponential backoff. A `max_retries` clamp (ceiling 10) in config makes the overflow unreachable.
+
+**Tech Stack:** Rust 2024, tokio (`time::sleep`, `time::pause`/`advance` for tests via `features=["full"]`), `thiserror`, workspace crates `lunaroute-egress`, `lunaroute-server`.
+
+## Global Constraints
+
+- Rust edition 2024, MSRV 1.94 (workspace `Cargo.toml`). rustfmt: max width 100, 4-space, Unix.
+- No new dependencies. `tokio` (workspace, `features=["full"]` → includes `test-util`), `thiserror`, `tracing`, `lunaroute-egress` already available.
+- `EgressError::RateLimitExceeded { retry_after_secs: Option<u64> }` already exists (lib.rs:45) — no new variants.
+- `with_retry`'s signature `pub async fn with_retry<F, Fut, T>(max_retries: u32, operation: F) -> Result<T>` is UNCHANGED. The 4 production call sites (anthropic.rs:355, openai.rs:402/504/1158/1212) need no edits.
+- `parse_retry_after` is already `pub` in the egress crate (`crate::parse_retry_after`), already used by the OpenAI path. No new public API.
+- No DB migrations. No new config fields (`max_retries` already exists; we only clamp it).
+- Each task ends with `cargo test` green for the affected crate(s) and a commit.
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `crates/lunaroute-egress/src/anthropic.rs` | Modify | `handle_anthropic_response` returns `RateLimitExceeded` for 429 (reads `retry-after`). |
+| `crates/lunaroute-egress/src/client.rs` | Modify | `with_retry` restructured: `RateLimitExceeded` retryable, honors `retry_after_secs` (cap 60s, bail on longer), saturating exponential backoff. New `RATE_LIMIT_SLEEP_CAP_SECS` const. |
+| `crates/lunaroute-server/src/config.rs` | Modify | `to_http_client_config` clamps `max_retries` to 10 with a warn log. |
+| `crates/lunaroute-egress/src/retry_after.rs` | (unchanged) | `parse_retry_after` is reused as-is. |
+| `crates/lunaroute-egress/src/lib.rs` | (unchanged) | `EgressError::RateLimitExceeded` reused as-is. |
+
+---
+
+### Task 1: Anthropic returns `RateLimitExceeded` for 429 (Fix 1a, fixes #8)
+
+**Files:**
+- Modify: `crates/lunaroute-egress/src/anthropic.rs` (`handle_anthropic_response` ~line 1022, `mod tests` ~line 1047)
+
+**Interfaces:**
+- Consumes: `crate::parse_retry_after` (already pub), `EgressError` (in scope), `debug!` (in scope via `tracing`).
+- Produces: `handle_anthropic_response` returns `EgressError::RateLimitExceeded { retry_after_secs }` for 429 (instead of `ProviderError`).
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/lunaroute-egress/src/anthropic.rs`, inside `mod tests` (starts at line 1047), add this test near the other `test_from_anthropic_response_*` tests. `handle_anthropic_response` is a trait method on `reqwest::Response` (via the `AnthropicResponseExt` trait, line ~1015), so the test builds a `reqwest::Response` from an `http::Response` (reqwest 0.13.3 has `impl<T: Into<Body>> From<http::Response<T>> for Response`, verified). `http` is already a workspace dep used by `lunaroute-egress`.
+
+```rust
+    #[tokio::test]
+    async fn test_handle_anthropic_response_429_returns_rate_limit_exceeded() {
+        use http::Response;
+        use reqwest::Response as ReqResponse;
+
+        // Build an http::Response with 429 + retry-after, convert to reqwest.
+        let http_resp = Response::builder()
+            .status(429)
+            .header("retry-after", "30")
+            .body(r#"{"type":"error","error":{"type":"rate_limit_error","message":"too many requests"}}"#.to_string())
+            .unwrap();
+        let resp: ReqResponse = http_resp.into();
+
+        let result = resp.handle_anthropic_response().await;
+
+        match result {
+            Err(EgressError::RateLimitExceeded { retry_after_secs }) => {
+                assert_eq!(retry_after_secs, Some(30));
+            }
+            other => panic!("expected RateLimitExceeded{{Some(30)}}, got {:?}", other),
+        }
+    }
+```
+
+(`EgressError` is in scope via `use crate::EgressError;` or `use super::*;` — check the existing `mod tests` imports at the top of the test module and mirror. `handle_anthropic_response` is in scope via `AnthropicResponseExt` — the test module likely already `use super::*;` to access it; verify and add `use super::AnthropicResponseExt;` if needed.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p lunaroute-egress --lib anthropic::tests::test_handle_anthropic_response_429_returns_rate_limit_exceeded`
+Expected: FAIL — the current `handle_anthropic_response` returns `ProviderError { status_code: 429, ... }` for 429, so the test's `Err(RateLimitExceeded{...})` match fails (or panics).
+
+- [ ] **Step 3: Make `handle_anthropic_response` return `RateLimitExceeded` for 429**
+
+In `crates/lunaroute-egress/src/anthropic.rs`, replace the `handle_anthropic_response` method (~line 1022) with:
+
+```rust
+    async fn handle_anthropic_response(self) -> Result<AnthropicResponse> {
+        let status = self.status();
+
+        // Capture retry-after header before consuming response
+        let retry_after_secs = self
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(crate::parse_retry_after);
+
+        if !status.is_success() {
+            let status_code = status.as_u16();
+            let body = self
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unable to read error body".to_string());
+
+            return Err(if status_code == 429 {
+                debug!(
+                    retry_after_secs = ?retry_after_secs,
+                    "Anthropic rate limit exceeded"
+                );
+                EgressError::RateLimitExceeded { retry_after_secs }
+            } else {
+                EgressError::ProviderError {
+                    status_code,
+                    message: body,
+                }
+            });
+        }
+
+        let response = self.json::<AnthropicResponse>().await.map_err(|e| {
+            EgressError::ParseError(format!("Failed to parse Anthropic response: {}", e))
+        })?;
+
+        Ok(response)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p lunaroute-egress --lib anthropic`
+Expected: PASS — the new 429 test passes (returns `RateLimitExceeded{Some(30)}`), and existing `test_from_anthropic_response_*` tests still pass (they don't exercise 429).
+
+Run: `cargo test -p lunaroute-integration-tests --test error_handling_with_recording`
+Expected: PASS — `test_anthropic_rate_limit_429_with_recording` still passes (the proxy still surfaces a 429; the internal error variant changed but the client-visible behavior is the same status).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/lunaroute-egress/src/anthropic.rs
+git commit -m "fix(egress): Anthropic 429 returns RateLimitExceeded with retry-after
+
+handle_anthropic_response now reads the retry-after header and returns
+RateLimitExceeded{retry_after_secs} for 429, mirroring the OpenAI handler.
+Previously it returned ProviderError for all non-success (including 429),
+never reading retry-after. Both providers now return the same error variant
+for 429, enabling with_retry to honor retry-after uniformly."
+```
+
+---
+
+### Task 2: `with_retry` honors `retry-after` + saturating backoff (Fix 1b + 2a, fixes #11 + #14)
+
+**Files:**
+- Modify: `crates/lunaroute-egress/src/client.rs` (`with_retry` ~line 127, new module-scope const, `mod tests`)
+
+**Interfaces:**
+- Consumes: `EgressError::RateLimitExceeded { retry_after_secs: Option<u64> }`, `tokio::time::sleep`, `Duration`.
+- Produces: `with_retry` retries `RateLimitExceeded` honoring `retry_after_secs` (cap `RATE_LIMIT_SLEEP_CAP_SECS`), saturating exponential backoff otherwise. Signature unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `crates/lunaroute-egress/src/client.rs`, inside `mod tests` (after the existing `test_retry_*` tests ~line 256), add these tests. Use `tokio::time::pause()` so the sleeps don't block real wall-clock:
+
+```rust
+    #[tokio::test]
+    async fn test_retry_rate_limit_exceeded_with_retry_after_is_retried() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::Arc;
+
+        // 429 with retry-after:2s should be retried (honoring 2s) and succeed on attempt 3.
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_clone = attempts.clone();
+
+        tokio::time::pause();
+        let result: Result<i32, EgressError> = with_retry(3, move || {
+            let a = attempts_clone.clone();
+            async move {
+                let n = a.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    Err(EgressError::RateLimitExceeded { retry_after_secs: Some(2) })
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3, "should have attempted 3 times");
+    }
+
+    #[tokio::test]
+    async fn test_retry_rate_limit_exceeded_bails_when_retry_after_exceeds_cap() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::Arc;
+
+        // 429 with retry-after:86400 (daily quota, > 60s cap) should bail immediately,
+        // NOT retry, returning the RateLimitExceeded error.
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_clone = attempts.clone();
+
+        let result: Result<i32, EgressError> = with_retry(3, move || {
+            let a = attempts_clone.clone();
+            async move {
+                a.fetch_add(1, Ordering::SeqCst);
+                Err(EgressError::RateLimitExceeded { retry_after_secs: Some(86400) })
+            }
+        })
+        .await;
+
+        assert!(result.is_err());
+        match result {
+            Err(EgressError::RateLimitExceeded { retry_after_secs }) => {
+                assert_eq!(retry_after_secs, Some(86400));
+            }
+            other => panic!("expected RateLimitExceeded, got {:?}", other),
+        }
+        assert_eq!(attempts.load(Ordering::SeqCst), 1, "must NOT retry when retry-after exceeds cap");
+    }
+
+    #[tokio::test]
+    async fn test_retry_rate_limit_exceeded_no_header_uses_exponential_backoff() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::Arc;
+
+        // 429 with no retry-after should retry with exponential backoff and succeed.
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_clone = attempts.clone();
+
+        tokio::time::pause();
+        let result: Result<i32, EgressError> = with_retry(3, move || {
+            let a = attempts_clone.clone();
+            async move {
+                let n = a.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    Err(EgressError::RateLimitExceeded { retry_after_secs: None })
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_backoff_does_not_overflow_for_large_max_retries() {
+        // max_retries=65 would overflow 2u64.pow(64) today (panic in debug).
+        // The saturating expression must not panic. The operation succeeds on
+        // the first attempt, so no actual sleep happens — this only checks
+        // the backoff EXPRESSION compiles and the fn doesn't panic on setup.
+        let result: Result<i32, EgressError> = with_retry(65, || async { Ok(42) }).await;
+        assert_eq!(result.unwrap(), 42);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p lunaroute-egress --lib client::tests::test_retry_rate_limit_exceeded_with_retry_after_is_retried`
+Expected: FAIL — today `with_retry` does NOT retry `RateLimitExceeded` (`_ => false`), so the operation is called only once and the test's `Ok(42)` is never reached (returns `Err(RateLimitExceeded{...})`).
+
+Run: `cargo test -p lunaroute-egress --lib client::tests::test_backoff_does_not_overflow_for_large_max_retries`
+Expected: PASS already today on release, but PANIC in debug builds (`2u64.pow(64)` overflow). This test documents the fix.
+
+- [ ] **Step 3: Add the `RATE_LIMIT_SLEEP_CAP_SECS` constant and restructure `with_retry`**
+
+In `crates/lunaroute-egress/src/client.rs`, add the constant just above `with_retry` (~line 125):
+
+```rust
+/// Maximum sleep (seconds) for a single rate-limit retry. Longer retry-after
+/// values (e.g. daily quotas ~86400s) bail to the client immediately instead
+/// of blocking the request for minutes. 60s covers real-world per-minute
+/// rate limits from both OpenAI and Anthropic.
+const RATE_LIMIT_SLEEP_CAP_SECS: u64 = 60;
+```
+
+Replace the entire `with_retry` fn body (lines ~127-179) with the restructured version:
+
+```rust
+pub async fn with_retry<F, Fut, T>(max_retries: u32, operation: F) -> Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut last_error = None;
+
+    for attempt in 0..=max_retries {
+        // Sleep before retries (skipped on the first attempt). The sleep
+        // duration is driven by the PREVIOUS attempt's error so we can honor
+        // retry-after for rate limits.
+        if attempt > 0 {
+            let backoff_ms = match &last_error {
+                Some(EgressError::RateLimitExceeded {
+                    retry_after_secs: Some(ras),
+                }) => {
+                    if *ras > RATE_LIMIT_SLEEP_CAP_SECS {
+                        // retry-after too long: bail to the client immediately.
+                        debug!(
+                            retry_after_secs = ras,
+                            cap = RATE_LIMIT_SLEEP_CAP_SECS,
+                            "rate-limit retry-after exceeds cap; returning error to client"
+                        );
+                        return Err(last_error.unwrap());
+                    }
+                    // Honor the provider's retry-after (seconds -> ms).
+                    ras.saturating_mul(1000)
+                }
+                _ => {
+                    // Exponential backoff for non-rate-limit errors, or rate
+                    // limit with no retry-after header. Saturating: prevents
+                    // overflow for large max_retries (2u64.pow(64) would panic).
+                    (1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100)
+                }
+            };
+            debug!(
+                "Retrying request after {}ms (attempt {}/{})",
+                backoff_ms, attempt, max_retries
+            );
+            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+        }
+
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                // Check if error is retryable
+                let should_retry = match &e {
+                    EgressError::HttpError(req_err) => {
+                        // Retry on network errors, connection errors, timeouts
+                        req_err.is_connect() || req_err.is_timeout() || req_err.is_request()
+                    }
+                    EgressError::ProviderError { status_code, .. } => {
+                        // Retry on 429 (rate limit), 500, 502, 503, 504.
+                        // 429 here is a defensive fallback: providers SHOULD
+                        // return RateLimitExceeded for 429 (honored in the
+                        // sleep logic above), but if a path returns
+                        // ProviderError for 429 it still retries with backoff.
+                        matches!(status_code, 429 | 500 | 502 | 503 | 504)
+                    }
+                    EgressError::RateLimitExceeded { .. } => true,
+                    EgressError::Timeout(_) => true,
+                    _ => false,
+                };
+
+                if should_retry && attempt < max_retries {
+                    warn!(
+                        "Request failed (attempt {}/{}): {:?}",
+                        attempt + 1,
+                        max_retries,
+                        e
+                    );
+                    last_error = Some(e);
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        EgressError::ConfigError("Retry loop exited unexpectedly".to_string())
+    }))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p lunaroute-egress --lib client`
+Expected: PASS — all 4 new tests pass (rate-limit-with-retry-after retries and succeeds; bail-on-long-retry-after returns the error after 1 attempt; no-header uses backoff and succeeds; large-max-retries doesn't panic). The existing `test_retry_success_first_attempt`, `test_retry_non_retryable_error`, `test_error_display_formatting` still pass.
+
+- [ ] **Step 5: Run the broader egress suite**
+
+Run: `cargo test -p lunaroute-egress`
+Expected: PASS (no regression in anthropic/openai/streaming tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/lunaroute-egress/src/client.rs
+git commit -m "fix(egress): with_retry honors retry-after + saturating backoff
+
+with_retry now retries RateLimitExceeded, sleeping for retry_after_secs
+(capped at 60s/retry) and bailing to the client immediately when
+retry-after exceeds the cap (e.g. daily quotas). Falls back to exponential
+backoff when retry-after is absent. Previously RateLimitExceeded was never
+retried (OpenAI 429 failed immediately) while ProviderError 429 was retried
+blindly ignoring retry-after (Anthropic 429). Also fixes the
+2u64.pow(attempt-1) overflow panic for max_retries>=65 via a saturating
+checked_shl expression."
+```
+
+---
+
+### Task 3: Clamp `max_retries` at config parse (Fix 2b, completes #14)
+
+**Files:**
+- Modify: `crates/lunaroute-server/src/config.rs` (`to_http_client_config` ~line 225, `mod tests`)
+
+**Interfaces:**
+- Consumes: `lunaroute_egress::HttpClientConfig`, `tracing::warn`.
+- Produces: `to_http_client_config` clamps `max_retries` to 10 with a warn log.
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/lunaroute-server/src/config.rs`, inside `mod tests` (find via `rg -n 'mod tests' crates/lunaroute-server/src/config.rs`), add:
+
+```rust
+    #[test]
+    fn test_to_http_client_config_clamps_max_retries_to_10() {
+        let provider = ProviderSettings {
+            timeout_secs: None,
+            connect_timeout_secs: None,
+            pool_max_idle_per_host: None,
+            pool_idle_timeout_secs: None,
+            tcp_keepalive_secs: None,
+            max_retries: Some(100),
+            enable_pool_metrics: None,
+            // ... other fields default as in the existing test_to_http_client_config tests
+        };
+        // Fill any other REQUIRED fields of ProviderSettings by mirroring an
+        // existing test that constructs ProviderSettings (rg -n 'ProviderSettings {' in this file).
+
+        let config = provider.to_http_client_config();
+        assert_eq!(config.max_retries, 10, "max_retries must be clamped to 10");
+    }
+
+    #[test]
+    fn test_to_http_client_config_preserves_max_retries_under_10() {
+        let provider = ProviderSettings {
+            // ... same as above ...
+            max_retries: Some(5),
+            // ...
+        };
+        let config = provider.to_http_client_config();
+        assert_eq!(config.max_retries, 5, "max_retries under the ceiling is unchanged");
+    }
+```
+
+(Read the existing `ProviderSettings` construction in the test module — e.g. `test_merge_http_client_env_*` tests construct `ProviderSettings` — and mirror ALL required fields. `ProviderSettings` is the struct at config.rs:~134 with fields `api_key`, `base_url`, `enabled`, `http_client`, etc. The `http_client: Option<HttpClientSettings>` field is what carries `max_retries`. Look at `test_merge_http_client_env_all_variables` (~line 838) for the exact construction pattern and mirror it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p lunaroute-server config::tests::test_to_http_client_config_clamps_max_retries_to_10`
+Expected: FAIL — today `to_http_client_config` sets `max_retries: self.max_retries.unwrap_or(defaults.max_retries)` with no clamp, so `Some(100)` yields `100`, not `10`.
+
+- [ ] **Step 3: Add the clamp + warn log**
+
+In `crates/lunaroute-server/src/config.rs`, in `to_http_client_config` (~line 225), replace the `max_retries:` line:
+
+```rust
+            max_retries: self.max_retries.unwrap_or(defaults.max_retries),
+```
+
+with:
+
+```rust
+            max_retries: {
+                let requested = self.max_retries.unwrap_or(defaults.max_retries);
+                if requested > 10 {
+                    warn!(
+                        requested = requested,
+                        clamped = 10,
+                        "max_retries exceeds safe ceiling; clamping to 10"
+                    );
+                    10
+                } else {
+                    requested
+                }
+            },
+```
+
+(`warn` is already imported via `tracing` / `use tracing::{...}` at the top of `config.rs` — verify with `rg -n 'use tracing' crates/lunaroute-server/src/config.rs`; if `warn` isn't in scope, add it to the existing `use tracing::...` line.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p lunaroute-server config`
+Expected: PASS — both new tests pass (clamp to 10; under-10 unchanged). Existing `test_merge_http_client_env_*` tests unaffected (they use small `max_retries` values like 5).
+
+- [ ] **Step 5: Run the server suite**
+
+Run: `cargo test -p lunaroute-server`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/lunaroute-server/src/config.rs
+git commit -m "fix(config): clamp max_retries to 10 with warn log
+
+to_http_client_config now clamps max_retries to a safe ceiling of 10 (with
+a warn log when clamping). Makes the with_retry backoff overflow unreachable
+by construction (belt-and-suspenders with the saturating checked_shl
+expression in with_retry). 10 retries x ~60s worst-case = 600s, beyond sane
+for a proxy willing to retry."
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run the full workspace test suite:** `cargo test --workspace --all-features`
+Expected: PASS (all tests green; only DB/real-API tests ignored as before).
+
+- [ ] **Run the exact CI gates locally:**
+  - `cargo fmt --all -- --check`
+  - `cargo clippy --workspace --all-features -- -D warnings`
+  - `cargo check --workspace --all-features`
+  - `cargo test --workspace --all-features`
+Expected: all clean.
+
+## Self-Review
+
+**1. Spec coverage:**
+- Fix 1a (Anthropic → `RateLimitExceeded`) → Task 1. ✓
+- Fix 1b (`with_retry` honors retry-after) → Task 2. ✓
+- Fix 2a (saturating backoff) → Task 2 (embedded in the restructured `with_retry`). ✓
+- Fix 2b (config clamp) → Task 3. ✓
+- Tests per fix → Tasks 1, 2, 3 each have tests. ✓
+
+**2. Placeholder scan:** No "TBD"/"TODO"/"add appropriate". The two hedged instructions (Task 1 Step 1 test-harness fallback; Task 3 Step 1 "mirror an existing test's `ProviderSettings` construction") give concrete fallbacks. The `... other fields default` in the Task 3 test snippet is a placeholder for the implementer to fill by reading an existing test — this is acceptable because the exact field set of `ProviderSettings` is large and the implementer is told exactly where to find a working example (`test_merge_http_client_env_all_variables`). ✓
+
+**3. Type consistency:**
+- `EgressError::RateLimitExceeded { retry_after_secs: Option<u64> }` — consistent across Task 1 (Anthropic handler returns it), Task 2 (`with_retry` matches it). ✓
+- `RATE_LIMIT_SLEEP_CAP_SECS: u64 = 60` — consistent in Task 2 const + match + tests (86400 > 60 → bail; 2 <= 60 → retry). ✓
+- `with_retry(max_retries: u32, operation: F)` signature unchanged — Task 2 preserves it; the 4 production call sites need no edits. ✓
+- `(1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100)` — the saturating backoff in Task 2 matches the spec's Fix 2a. ✓
+- `max_retries.min(10)` clamp — Task 3 clamps to 10, matching the spec's Fix 2b ceiling. ✓
+- `tokio::time::pause()` used in Task 2 tests — available via `tokio` `features=["full"]` (includes `test-util`). ✓
+
+No issues found. Plan is complete.

--- a/docs/superpowers/plans/2026-07-02-retry-rate-limit-consistency.md
+++ b/docs/superpowers/plans/2026-07-02-retry-rate-limit-consistency.md
@@ -1,420 +1,106 @@
-# Retry / Rate-Limit Consistency Implementation Plan
+# Retry / Rate-Limit Consistency Implementation Plan (revised)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make 429 handling consistent across providers (both return `RateLimitExceeded{retry_after}`; `with_retry` honors `retry-after`, capped at 60s/retry, bailing on longer), and fix the backoff overflow panic for large `max_retries`.
+**Goal:** Fix the backoff overflow panic in `with_retry` for large `max_retries` (issue #14). Issue #8 (Anthropic 429) was already fixed by Task 1 (commit `d32d3fe`); issue #11 was re-evaluated as a misdiagnosis (egress correctly does NOT retry `RateLimitExceeded` — it propagates to the routing layer's failover).
 
-**Architecture:** `handle_anthropic_response` mirrors the OpenAI handler: read `retry-after`, return `RateLimitExceeded` for 429. `with_retry` is restructured so the retry sleep is driven by the *previous attempt's error* (so `retry_after_secs` is available): `RateLimitExceeded{Some(ras)}` sleeps `ras*1000ms` if `ras <= 60` else bails; everything else uses saturating exponential backoff. A `max_retries` clamp (ceiling 10) in config makes the overflow unreachable.
+**Architecture:** The routing layer (`lunaroute-routing`) owns 429 retry/failover (reads `retry-after`, switches to an alternative provider). The egress `with_retry` must NOT retry `RateLimitExceeded` — it propagates up. `with_retry` DOES retry transient non-429 errors (network, timeout, 500/502/503/504) on the same provider, using exponential backoff. The backoff expression `2u64.pow(attempt-1)*100` panics for `max_retries ≥ 65`; this plan replaces it with a saturating expression and clamps `max_retries` to 10 in config. No 429-classification change, no loop restructure, no routing-layer change.
 
-**Tech Stack:** Rust 2024, tokio (`time::sleep`, `time::pause`/`advance` for tests via `features=["full"]`), `thiserror`, workspace crates `lunaroute-egress`, `lunaroute-server`.
+**Tech Stack:** Rust 2024, tokio (`time::pause`/`advance` for tests via `features=["full"]`), `tracing` (`warn`), workspace crates `lunaroute-egress`, `lunaroute-server`.
 
 ## Global Constraints
 
 - Rust edition 2024, MSRV 1.94 (workspace `Cargo.toml`). rustfmt: max width 100, 4-space, Unix.
-- No new dependencies. `tokio` (workspace, `features=["full"]` → includes `test-util`), `thiserror`, `tracing`, `lunaroute-egress` already available.
-- `EgressError::RateLimitExceeded { retry_after_secs: Option<u64> }` already exists (lib.rs:45) — no new variants.
-- `with_retry`'s signature `pub async fn with_retry<F, Fut, T>(max_retries: u32, operation: F) -> Result<T>` is UNCHANGED. The 4 production call sites (anthropic.rs:355, openai.rs:402/504/1158/1212) need no edits.
-- `parse_retry_after` is already `pub` in the egress crate (`crate::parse_retry_after`), already used by the OpenAI path. No new public API.
+- No new dependencies. `tokio` (workspace, `features=["full"]` → includes `test-util`), `tracing`, `lunaroute-egress` already available.
+- `with_retry`'s signature `pub async fn with_retry<F, Fut, T>(max_retries: u32, operation: F) -> Result<T>` is UNCHANGED. The 4 production call sites need no edits.
+- `EgressError::RateLimitExceeded { retry_after_secs: Option<u64> }` is UNCHANGED — and MUST remain non-retryable in `with_retry` (it propagates to the routing layer). Do NOT add `RateLimitExceeded` to the retryable classification.
+- The 429 classification in `with_retry` is UNCHANGED: `ProviderError{429}` stays retryable (defensive fallback for any path that still returns it); `RateLimitExceeded` stays non-retryable (`_ => false`).
 - No DB migrations. No new config fields (`max_retries` already exists; we only clamp it).
-- Each task ends with `cargo test` green for the affected crate(s) and a commit.
+- **Must not break `limits_alternative_strategy` tests** — they assert 429 failover at the routing layer (`.expect(1)` on the primary). This plan does NOT touch the 429 path, so those tests stay green.
 
 ## File Structure
 
 | File | Status | Responsibility |
 |---|---|---|
-| `crates/lunaroute-egress/src/anthropic.rs` | Modify | `handle_anthropic_response` returns `RateLimitExceeded` for 429 (reads `retry-after`). |
-| `crates/lunaroute-egress/src/client.rs` | Modify | `with_retry` restructured: `RateLimitExceeded` retryable, honors `retry_after_secs` (cap 60s, bail on longer), saturating exponential backoff. New `RATE_LIMIT_SLEEP_CAP_SECS` const. |
-| `crates/lunaroute-server/src/config.rs` | Modify | `to_http_client_config` clamps `max_retries` to 10 with a warn log. |
-| `crates/lunaroute-egress/src/retry_after.rs` | (unchanged) | `parse_retry_after` is reused as-is. |
-| `crates/lunaroute-egress/src/lib.rs` | (unchanged) | `EgressError::RateLimitExceeded` reused as-is. |
+| `crates/lunaroute-egress/src/client.rs` | Modify | Replace `2u64.pow(attempt-1)*100` with saturating `checked_shl`/`saturating_mul`. Add overflow-safety tests. |
+| `crates/lunaroute-server/src/config.rs` | Modify | `to_http_client_config` clamps `max_retries` to 10 with a warn log. Add clamp tests. |
 
 ---
 
-### Task 1: Anthropic returns `RateLimitExceeded` for 429 (Fix 1a, fixes #8)
+### Task 2 (revised): Saturating backoff + config clamp (fixes #14)
+
+**Note:** This replaces the original Task 2 (which made `with_retry` retry `RateLimitExceeded` — that change was reverted because it broke the routing layer's 429 failover design). The original Task 1 (Anthropic → `RateLimitExceeded`, commit `d32d3fe`) is DONE and stays. The original Task 3 (config clamp) folds into this task since the backoff + clamp both prevent the same overflow.
 
 **Files:**
-- Modify: `crates/lunaroute-egress/src/anthropic.rs` (`handle_anthropic_response` ~line 1022, `mod tests` ~line 1047)
+- Modify: `crates/lunaroute-egress/src/client.rs` (backoff expression ~line 152, `mod tests`)
+- Modify: `crates/lunaroute-server/src/config.rs` (`to_http_client_config` ~line 225, `mod tests`)
 
 **Interfaces:**
-- Consumes: `crate::parse_retry_after` (already pub), `EgressError` (in scope), `debug!` (in scope via `tracing`).
-- Produces: `handle_anthropic_response` returns `EgressError::RateLimitExceeded { retry_after_secs }` for 429 (instead of `ProviderError`).
-
-- [ ] **Step 1: Write the failing test**
-
-In `crates/lunaroute-egress/src/anthropic.rs`, inside `mod tests` (starts at line 1047), add this test near the other `test_from_anthropic_response_*` tests. `handle_anthropic_response` is a trait method on `reqwest::Response` (via the `AnthropicResponseExt` trait, line ~1015), so the test builds a `reqwest::Response` from an `http::Response` (reqwest 0.13.3 has `impl<T: Into<Body>> From<http::Response<T>> for Response`, verified). `http` is already a workspace dep used by `lunaroute-egress`.
-
-```rust
-    #[tokio::test]
-    async fn test_handle_anthropic_response_429_returns_rate_limit_exceeded() {
-        use http::Response;
-        use reqwest::Response as ReqResponse;
-
-        // Build an http::Response with 429 + retry-after, convert to reqwest.
-        let http_resp = Response::builder()
-            .status(429)
-            .header("retry-after", "30")
-            .body(r#"{"type":"error","error":{"type":"rate_limit_error","message":"too many requests"}}"#.to_string())
-            .unwrap();
-        let resp: ReqResponse = http_resp.into();
-
-        let result = resp.handle_anthropic_response().await;
-
-        match result {
-            Err(EgressError::RateLimitExceeded { retry_after_secs }) => {
-                assert_eq!(retry_after_secs, Some(30));
-            }
-            other => panic!("expected RateLimitExceeded{{Some(30)}}, got {:?}", other),
-        }
-    }
-```
-
-(`EgressError` is in scope via `use crate::EgressError;` or `use super::*;` — check the existing `mod tests` imports at the top of the test module and mirror. `handle_anthropic_response` is in scope via `AnthropicResponseExt` — the test module likely already `use super::*;` to access it; verify and add `use super::AnthropicResponseExt;` if needed.)
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cargo test -p lunaroute-egress --lib anthropic::tests::test_handle_anthropic_response_429_returns_rate_limit_exceeded`
-Expected: FAIL — the current `handle_anthropic_response` returns `ProviderError { status_code: 429, ... }` for 429, so the test's `Err(RateLimitExceeded{...})` match fails (or panics).
-
-- [ ] **Step 3: Make `handle_anthropic_response` return `RateLimitExceeded` for 429**
-
-In `crates/lunaroute-egress/src/anthropic.rs`, replace the `handle_anthropic_response` method (~line 1022) with:
-
-```rust
-    async fn handle_anthropic_response(self) -> Result<AnthropicResponse> {
-        let status = self.status();
-
-        // Capture retry-after header before consuming response
-        let retry_after_secs = self
-            .headers()
-            .get("retry-after")
-            .and_then(|v| v.to_str().ok())
-            .and_then(crate::parse_retry_after);
-
-        if !status.is_success() {
-            let status_code = status.as_u16();
-            let body = self
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unable to read error body".to_string());
-
-            return Err(if status_code == 429 {
-                debug!(
-                    retry_after_secs = ?retry_after_secs,
-                    "Anthropic rate limit exceeded"
-                );
-                EgressError::RateLimitExceeded { retry_after_secs }
-            } else {
-                EgressError::ProviderError {
-                    status_code,
-                    message: body,
-                }
-            });
-        }
-
-        let response = self.json::<AnthropicResponse>().await.map_err(|e| {
-            EgressError::ParseError(format!("Failed to parse Anthropic response: {}", e))
-        })?;
-
-        Ok(response)
-    }
-```
-
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `cargo test -p lunaroute-egress --lib anthropic`
-Expected: PASS — the new 429 test passes (returns `RateLimitExceeded{Some(30)}`), and existing `test_from_anthropic_response_*` tests still pass (they don't exercise 429).
-
-Run: `cargo test -p lunaroute-integration-tests --test error_handling_with_recording`
-Expected: PASS — `test_anthropic_rate_limit_429_with_recording` still passes (the proxy still surfaces a 429; the internal error variant changed but the client-visible behavior is the same status).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add crates/lunaroute-egress/src/anthropic.rs
-git commit -m "fix(egress): Anthropic 429 returns RateLimitExceeded with retry-after
-
-handle_anthropic_response now reads the retry-after header and returns
-RateLimitExceeded{retry_after_secs} for 429, mirroring the OpenAI handler.
-Previously it returned ProviderError for all non-success (including 429),
-never reading retry-after. Both providers now return the same error variant
-for 429, enabling with_retry to honor retry-after uniformly."
-```
-
----
-
-### Task 2: `with_retry` honors `retry-after` + saturating backoff (Fix 1b + 2a, fixes #11 + #14)
-
-**Files:**
-- Modify: `crates/lunaroute-egress/src/client.rs` (`with_retry` ~line 127, new module-scope const, `mod tests`)
-
-**Interfaces:**
-- Consumes: `EgressError::RateLimitExceeded { retry_after_secs: Option<u64> }`, `tokio::time::sleep`, `Duration`.
-- Produces: `with_retry` retries `RateLimitExceeded` honoring `retry_after_secs` (cap `RATE_LIMIT_SLEEP_CAP_SECS`), saturating exponential backoff otherwise. Signature unchanged.
+- Consumes: `EgressError::ProviderError` (for the retry-path overflow test), `tokio::time::pause`, `tracing::warn`.
+- Produces: `with_retry` uses a saturating backoff expression; `to_http_client_config` clamps `max_retries` to 10. No signature changes.
 
 - [ ] **Step 1: Write the failing tests**
 
-In `crates/lunaroute-egress/src/client.rs`, inside `mod tests` (after the existing `test_retry_*` tests ~line 256), add these tests. Use `tokio::time::pause()` so the sleeps don't block real wall-clock:
+**(a) Egress backoff overflow tests** — in `crates/lunaroute-egress/src/client.rs`, inside `mod tests` (after the existing `test_retry_*` tests ~line 256). The crate's `Result<T>` alias takes ONE generic param (`pub type Result<T> = std::result::Result<T, EgressError>`), so use `Result<i32>`, NOT `Result<i32, EgressError>`.
 
 ```rust
     #[tokio::test]
-    async fn test_retry_rate_limit_exceeded_with_retry_after_is_retried() {
+    async fn test_backoff_does_not_overflow_for_large_max_retries_success_path() {
+        // max_retries=65 would overflow 2u64.pow(64) today (panic in debug).
+        // Saturating expression must not panic. Operation succeeds on first
+        // attempt, so no actual sleep — this checks the expression compiles
+        // and the fn doesn't panic on setup.
+        let result: Result<i32> = with_retry(65, || async { Ok(42) }).await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn test_backoff_does_not_overflow_for_large_max_retries_retry_path() {
+        // Force the retry path with a non-429 retryable error and max_retries=65.
+        // The backoff expression is evaluated on every retry; with the old
+        // 2u64.pow(attempt-1) this would panic at attempt=64. Saturating
+        // expression must not panic. Uses tokio::time::pause so the sleeps
+        // don't block real wall-clock.
         use std::sync::atomic::{AtomicU32, Ordering};
         use std::sync::Arc;
 
-        // 429 with retry-after:2s should be retried (honoring 2s) and succeed on attempt 3.
         let attempts = Arc::new(AtomicU32::new(0));
         let attempts_clone = attempts.clone();
 
         tokio::time::pause();
-        let result: Result<i32, EgressError> = with_retry(3, move || {
-            let a = attempts_clone.clone();
-            async move {
-                let n = a.fetch_add(1, Ordering::SeqCst);
-                if n < 2 {
-                    Err(EgressError::RateLimitExceeded { retry_after_secs: Some(2) })
-                } else {
-                    Ok(42)
-                }
-            }
-        })
-        .await;
-
-        assert_eq!(result.unwrap(), 42);
-        assert_eq!(attempts.load(Ordering::SeqCst), 3, "should have attempted 3 times");
-    }
-
-    #[tokio::test]
-    async fn test_retry_rate_limit_exceeded_bails_when_retry_after_exceeds_cap() {
-        use std::sync::atomic::{AtomicU32, Ordering};
-        use std::sync::Arc;
-
-        // 429 with retry-after:86400 (daily quota, > 60s cap) should bail immediately,
-        // NOT retry, returning the RateLimitExceeded error.
-        let attempts = Arc::new(AtomicU32::new(0));
-        let attempts_clone = attempts.clone();
-
-        let result: Result<i32, EgressError> = with_retry(3, move || {
+        let result: Result<i32> = with_retry(65, move || {
             let a = attempts_clone.clone();
             async move {
                 a.fetch_add(1, Ordering::SeqCst);
-                Err(EgressError::RateLimitExceeded { retry_after_secs: Some(86400) })
+                // Non-429 retryable error -> egress retries with exponential backoff.
+                Err(EgressError::ProviderError {
+                    status_code: 500,
+                    message: "Internal error".to_string(),
+                })
             }
         })
         .await;
 
         assert!(result.is_err());
-        match result {
-            Err(EgressError::RateLimitExceeded { retry_after_secs }) => {
-                assert_eq!(retry_after_secs, Some(86400));
-            }
-            other => panic!("expected RateLimitExceeded, got {:?}", other),
-        }
-        assert_eq!(attempts.load(Ordering::SeqCst), 1, "must NOT retry when retry-after exceeds cap");
-    }
-
-    #[tokio::test]
-    async fn test_retry_rate_limit_exceeded_no_header_uses_exponential_backoff() {
-        use std::sync::atomic::{AtomicU32, Ordering};
-        use std::sync::Arc;
-
-        // 429 with no retry-after should retry with exponential backoff and succeed.
-        let attempts = Arc::new(AtomicU32::new(0));
-        let attempts_clone = attempts.clone();
-
-        tokio::time::pause();
-        let result: Result<i32, EgressError> = with_retry(3, move || {
-            let a = attempts_clone.clone();
-            async move {
-                let n = a.fetch_add(1, Ordering::SeqCst);
-                if n < 2 {
-                    Err(EgressError::RateLimitExceeded { retry_after_secs: None })
-                } else {
-                    Ok(42)
-                }
-            }
-        })
-        .await;
-
-        assert_eq!(result.unwrap(), 42);
-        assert_eq!(attempts.load(Ordering::SeqCst), 3);
-    }
-
-    #[tokio::test]
-    async fn test_backoff_does_not_overflow_for_large_max_retries() {
-        // max_retries=65 would overflow 2u64.pow(64) today (panic in debug).
-        // The saturating expression must not panic. The operation succeeds on
-        // the first attempt, so no actual sleep happens — this only checks
-        // the backoff EXPRESSION compiles and the fn doesn't panic on setup.
-        let result: Result<i32, EgressError> = with_retry(65, || async { Ok(42) }).await;
-        assert_eq!(result.unwrap(), 42);
+        // All 66 attempts (0..=65) ran without panicking.
+        assert_eq!(attempts.load(Ordering::SeqCst), 66);
     }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `cargo test -p lunaroute-egress --lib client::tests::test_retry_rate_limit_exceeded_with_retry_after_is_retried`
-Expected: FAIL — today `with_retry` does NOT retry `RateLimitExceeded` (`_ => false`), so the operation is called only once and the test's `Ok(42)` is never reached (returns `Err(RateLimitExceeded{...})`).
-
-Run: `cargo test -p lunaroute-egress --lib client::tests::test_backoff_does_not_overflow_for_large_max_retries`
-Expected: PASS already today on release, but PANIC in debug builds (`2u64.pow(64)` overflow). This test documents the fix.
-
-- [ ] **Step 3: Add the `RATE_LIMIT_SLEEP_CAP_SECS` constant and restructure `with_retry`**
-
-In `crates/lunaroute-egress/src/client.rs`, add the constant just above `with_retry` (~line 125):
-
-```rust
-/// Maximum sleep (seconds) for a single rate-limit retry. Longer retry-after
-/// values (e.g. daily quotas ~86400s) bail to the client immediately instead
-/// of blocking the request for minutes. 60s covers real-world per-minute
-/// rate limits from both OpenAI and Anthropic.
-const RATE_LIMIT_SLEEP_CAP_SECS: u64 = 60;
-```
-
-Replace the entire `with_retry` fn body (lines ~127-179) with the restructured version:
-
-```rust
-pub async fn with_retry<F, Fut, T>(max_retries: u32, operation: F) -> Result<T>
-where
-    F: Fn() -> Fut,
-    Fut: std::future::Future<Output = Result<T>>,
-{
-    let mut last_error = None;
-
-    for attempt in 0..=max_retries {
-        // Sleep before retries (skipped on the first attempt). The sleep
-        // duration is driven by the PREVIOUS attempt's error so we can honor
-        // retry-after for rate limits.
-        if attempt > 0 {
-            let backoff_ms = match &last_error {
-                Some(EgressError::RateLimitExceeded {
-                    retry_after_secs: Some(ras),
-                }) => {
-                    if *ras > RATE_LIMIT_SLEEP_CAP_SECS {
-                        // retry-after too long: bail to the client immediately.
-                        debug!(
-                            retry_after_secs = ras,
-                            cap = RATE_LIMIT_SLEEP_CAP_SECS,
-                            "rate-limit retry-after exceeds cap; returning error to client"
-                        );
-                        return Err(last_error.unwrap());
-                    }
-                    // Honor the provider's retry-after (seconds -> ms).
-                    ras.saturating_mul(1000)
-                }
-                _ => {
-                    // Exponential backoff for non-rate-limit errors, or rate
-                    // limit with no retry-after header. Saturating: prevents
-                    // overflow for large max_retries (2u64.pow(64) would panic).
-                    (1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100)
-                }
-            };
-            debug!(
-                "Retrying request after {}ms (attempt {}/{})",
-                backoff_ms, attempt, max_retries
-            );
-            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-        }
-
-        match operation().await {
-            Ok(result) => return Ok(result),
-            Err(e) => {
-                // Check if error is retryable
-                let should_retry = match &e {
-                    EgressError::HttpError(req_err) => {
-                        // Retry on network errors, connection errors, timeouts
-                        req_err.is_connect() || req_err.is_timeout() || req_err.is_request()
-                    }
-                    EgressError::ProviderError { status_code, .. } => {
-                        // Retry on 429 (rate limit), 500, 502, 503, 504.
-                        // 429 here is a defensive fallback: providers SHOULD
-                        // return RateLimitExceeded for 429 (honored in the
-                        // sleep logic above), but if a path returns
-                        // ProviderError for 429 it still retries with backoff.
-                        matches!(status_code, 429 | 500 | 502 | 503 | 504)
-                    }
-                    EgressError::RateLimitExceeded { .. } => true,
-                    EgressError::Timeout(_) => true,
-                    _ => false,
-                };
-
-                if should_retry && attempt < max_retries {
-                    warn!(
-                        "Request failed (attempt {}/{}): {:?}",
-                        attempt + 1,
-                        max_retries,
-                        e
-                    );
-                    last_error = Some(e);
-                } else {
-                    return Err(e);
-                }
-            }
-        }
-    }
-
-    Err(last_error.unwrap_or_else(|| {
-        EgressError::ConfigError("Retry loop exited unexpectedly".to_string())
-    }))
-}
-```
-
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `cargo test -p lunaroute-egress --lib client`
-Expected: PASS — all 4 new tests pass (rate-limit-with-retry-after retries and succeeds; bail-on-long-retry-after returns the error after 1 attempt; no-header uses backoff and succeeds; large-max-retries doesn't panic). The existing `test_retry_success_first_attempt`, `test_retry_non_retryable_error`, `test_error_display_formatting` still pass.
-
-- [ ] **Step 5: Run the broader egress suite**
-
-Run: `cargo test -p lunaroute-egress`
-Expected: PASS (no regression in anthropic/openai/streaming tests).
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add crates/lunaroute-egress/src/client.rs
-git commit -m "fix(egress): with_retry honors retry-after + saturating backoff
-
-with_retry now retries RateLimitExceeded, sleeping for retry_after_secs
-(capped at 60s/retry) and bailing to the client immediately when
-retry-after exceeds the cap (e.g. daily quotas). Falls back to exponential
-backoff when retry-after is absent. Previously RateLimitExceeded was never
-retried (OpenAI 429 failed immediately) while ProviderError 429 was retried
-blindly ignoring retry-after (Anthropic 429). Also fixes the
-2u64.pow(attempt-1) overflow panic for max_retries>=65 via a saturating
-checked_shl expression."
-```
-
----
-
-### Task 3: Clamp `max_retries` at config parse (Fix 2b, completes #14)
-
-**Files:**
-- Modify: `crates/lunaroute-server/src/config.rs` (`to_http_client_config` ~line 225, `mod tests`)
-
-**Interfaces:**
-- Consumes: `lunaroute_egress::HttpClientConfig`, `tracing::warn`.
-- Produces: `to_http_client_config` clamps `max_retries` to 10 with a warn log.
-
-- [ ] **Step 1: Write the failing test**
-
-In `crates/lunaroute-server/src/config.rs`, inside `mod tests` (find via `rg -n 'mod tests' crates/lunaroute-server/src/config.rs`), add:
+**(b) Config clamp tests** — in `crates/lunaroute-server/src/config.rs`, inside `mod tests` (find via `rg -n 'mod tests' crates/lunaroute-server/src/config.rs`). Mirror the `ProviderSettings` construction in `test_merge_http_client_env_all_variables` (~line 838) for ALL required fields. Read that test first and copy the struct literal shape.
 
 ```rust
     #[test]
     fn test_to_http_client_config_clamps_max_retries_to_10() {
+        // Construct a ProviderSettings with max_retries: Some(100), mirroring
+        // the field set in test_merge_http_client_env_all_variables (~line 838).
+        // Fill ALL required fields of ProviderSettings (and its http_client
+        // sub-struct) by copying from that existing test.
         let provider = ProviderSettings {
-            timeout_secs: None,
-            connect_timeout_secs: None,
-            pool_max_idle_per_host: None,
-            pool_idle_timeout_secs: None,
-            tcp_keepalive_secs: None,
-            max_retries: Some(100),
-            enable_pool_metrics: None,
-            // ... other fields default as in the existing test_to_http_client_config tests
+            // ... mirror test_merge_http_client_env_all_variables, but:
+            // http_client: Some(HttpClientSettings { max_retries: Some(100), .. }),
+            // (and all other fields as in the existing test)
         };
-        // Fill any other REQUIRED fields of ProviderSettings by mirroring an
-        // existing test that constructs ProviderSettings (rg -n 'ProviderSettings {' in this file).
-
         let config = provider.to_http_client_config();
         assert_eq!(config.max_retries, 10, "max_retries must be clamped to 10");
     }
@@ -422,23 +108,42 @@ In `crates/lunaroute-server/src/config.rs`, inside `mod tests` (find via `rg -n 
     #[test]
     fn test_to_http_client_config_preserves_max_retries_under_10() {
         let provider = ProviderSettings {
-            // ... same as above ...
-            max_retries: Some(5),
-            // ...
+            // ... same as above, but max_retries: Some(5)
         };
         let config = provider.to_http_client_config();
         assert_eq!(config.max_retries, 5, "max_retries under the ceiling is unchanged");
     }
 ```
 
-(Read the existing `ProviderSettings` construction in the test module — e.g. `test_merge_http_client_env_*` tests construct `ProviderSettings` — and mirror ALL required fields. `ProviderSettings` is the struct at config.rs:~134 with fields `api_key`, `base_url`, `enabled`, `http_client`, etc. The `http_client: Option<HttpClientSettings>` field is what carries `max_retries`. Look at `test_merge_http_client_env_all_variables` (~line 838) for the exact construction pattern and mirror it.)
+- [ ] **Step 2: Run tests to verify they fail**
 
-- [ ] **Step 2: Run test to verify it fails**
+Run: `cargo test -p lunaroute-egress --lib client::tests::test_backoff_does_not_overflow_for_large_max_retries_retry_path`
+Expected: FAIL — in debug builds, `2u64.pow(64)` panics at attempt 64 (overflow). In release, it wraps (test passes by accident — but the panic in debug is the bug). The `success_path` test may already pass (no retry → no overflow expression evaluated); it documents the fix.
 
 Run: `cargo test -p lunaroute-server config::tests::test_to_http_client_config_clamps_max_retries_to_10`
 Expected: FAIL — today `to_http_client_config` sets `max_retries: self.max_retries.unwrap_or(defaults.max_retries)` with no clamp, so `Some(100)` yields `100`, not `10`.
 
-- [ ] **Step 3: Add the clamp + warn log**
+- [ ] **Step 3: Saturating backoff expression (Fix 2a)**
+
+In `crates/lunaroute-egress/src/client.rs`, in `with_retry` (~line 152), replace:
+
+```rust
+            let backoff_ms = 2u64.pow(attempt - 1) * 100; // Exponential backoff: 100ms, 200ms, 400ms
+```
+
+with:
+
+```rust
+            // Exponential backoff: 100ms, 200ms, 400ms ... saturating to avoid
+            // overflow for large max_retries (2u64.pow(64) would panic; checked_shl
+            // + saturating_mul caps instead). For realistic max_retries (3-10)
+            // values are identical to today.
+            let backoff_ms = (1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100);
+```
+
+(`attempt` is `u32`; `u64::checked_shl` takes `u32`, so `1u64.checked_shl(attempt - 1)` compiles — `attempt - 1` is `u32`.) **No other change to `with_retry`** — the loop, the sleep placement, and the 429 classification are unchanged.
+
+- [ ] **Step 4: Config clamp (Fix 2b)**
 
 In `crates/lunaroute-server/src/config.rs`, in `to_http_client_config` (~line 225), replace the `max_retries:` line:
 
@@ -464,29 +169,34 @@ with:
             },
 ```
 
-(`warn` is already imported via `tracing` / `use tracing::{...}` at the top of `config.rs` — verify with `rg -n 'use tracing' crates/lunaroute-server/src/config.rs`; if `warn` isn't in scope, add it to the existing `use tracing::...` line.)
+Verify `warn` is in scope: `rg -n 'use tracing' crates/lunaroute-server/src/config.rs`. If `warn` isn't in the existing `use tracing::...` line, add it.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p lunaroute-egress --lib client`
+Expected: PASS — both new backoff tests pass (no panic on the retry path with max_retries=65); existing `test_retry_success_first_attempt`, `test_retry_non_retryable_error`, `test_error_display_formatting` still pass.
 
 Run: `cargo test -p lunaroute-server config`
-Expected: PASS — both new tests pass (clamp to 10; under-10 unchanged). Existing `test_merge_http_client_env_*` tests unaffected (they use small `max_retries` values like 5).
+Expected: PASS — both new clamp tests pass; existing `test_merge_http_client_env_*` tests unaffected (they use small max_retries like 5).
 
-- [ ] **Step 5: Run the server suite**
+- [ ] **Step 6: Run the broader suite — CRITICAL: confirm limits_alternative_strategy still passes**
 
-Run: `cargo test -p lunaroute-server`
-Expected: PASS.
+Run: `cargo test -p lunaroute-egress -p lunaroute-server -p lunaroute_integration_tests --test limits_alternative_strategy`
+Expected: PASS — the `limits_alternative_strategy` tests (which assert 429 failover at the routing layer) must be GREEN. This plan does NOT touch the 429 path, so they're unaffected. If any of these fail, STOP — the change went out of scope.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add crates/lunaroute-server/src/config.rs
-git commit -m "fix(config): clamp max_retries to 10 with warn log
+git add crates/lunaroute-egress/src/client.rs crates/lunaroute-server/src/config.rs
+git commit -m "fix(egress): saturating backoff + clamp max_retries to 10 (overflow fix)
 
-to_http_client_config now clamps max_retries to a safe ceiling of 10 (with
-a warn log when clamping). Makes the with_retry backoff overflow unreachable
-by construction (belt-and-suspenders with the saturating checked_shl
-expression in with_retry). 10 retries x ~60s worst-case = 600s, beyond sane
-for a proxy willing to retry."
+Replace 2u64.pow(attempt-1)*100 in with_retry with a saturating
+checked_shl/saturating_mul expression, and clamp max_retries to 10 in
+to_http_client_config (with a warn log). The old expression panicked in
+debug (wrapped in release) for max_retries>=65. For realistic max_retries
+(3-10) backoff values are unchanged. The 429 classification is UNCHANGED:
+RateLimitExceeded propagates to the routing layer's failover (not retried
+at egress); only transient non-429 errors retry at egress."
 ```
 
 ---
@@ -494,7 +204,7 @@ for a proxy willing to retry."
 ## Final Verification
 
 - [ ] **Run the full workspace test suite:** `cargo test --workspace --all-features`
-Expected: PASS (all tests green; only DB/real-API tests ignored as before).
+Expected: PASS (all tests green; only DB/real-API tests ignored as before). The `limits_alternative_strategy` suite must be green (6 tests, ~1-2s — NOT 360s).
 
 - [ ] **Run the exact CI gates locally:**
   - `cargo fmt --all -- --check`
@@ -506,20 +216,22 @@ Expected: all clean.
 ## Self-Review
 
 **1. Spec coverage:**
-- Fix 1a (Anthropic → `RateLimitExceeded`) → Task 1. ✓
-- Fix 1b (`with_retry` honors retry-after) → Task 2. ✓
-- Fix 2a (saturating backoff) → Task 2 (embedded in the restructured `with_retry`). ✓
-- Fix 2b (config clamp) → Task 3. ✓
-- Tests per fix → Tasks 1, 2, 3 each have tests. ✓
+- Fix 1 (Anthropic → `RateLimitExceeded`, fixes #8) → DONE (commit `d32d3fe`, Task 1, reviewed). ✓
+- Fix 2a (saturating backoff, fixes #14 overflow) → Task 2 Step 3. ✓
+- Fix 2b (config clamp, completes #14) → Task 2 Step 4. ✓
+- #11 re-evaluated as misdiagnosis → no code change (documented in spec). ✓
+- Tests per fix → Task 2 Steps 1 (tests). ✓
 
-**2. Placeholder scan:** No "TBD"/"TODO"/"add appropriate". The two hedged instructions (Task 1 Step 1 test-harness fallback; Task 3 Step 1 "mirror an existing test's `ProviderSettings` construction") give concrete fallbacks. The `... other fields default` in the Task 3 test snippet is a placeholder for the implementer to fill by reading an existing test — this is acceptable because the exact field set of `ProviderSettings` is large and the implementer is told exactly where to find a working example (`test_merge_http_client_env_all_variables`). ✓
+**2. Placeholder scan:** No "TBD"/"TODO". The config test snippet's `// ... mirror test_merge_http_client_env_all_variables` is a directed instruction to copy an existing test's `ProviderSettings` construction (with the exact source test named), not a vague placeholder. ✓
 
 **3. Type consistency:**
-- `EgressError::RateLimitExceeded { retry_after_secs: Option<u64> }` — consistent across Task 1 (Anthropic handler returns it), Task 2 (`with_retry` matches it). ✓
-- `RATE_LIMIT_SLEEP_CAP_SECS: u64 = 60` — consistent in Task 2 const + match + tests (86400 > 60 → bail; 2 <= 60 → retry). ✓
-- `with_retry(max_retries: u32, operation: F)` signature unchanged — Task 2 preserves it; the 4 production call sites need no edits. ✓
-- `(1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100)` — the saturating backoff in Task 2 matches the spec's Fix 2a. ✓
-- `max_retries.min(10)` clamp — Task 3 clamps to 10, matching the spec's Fix 2b ceiling. ✓
-- `tokio::time::pause()` used in Task 2 tests — available via `tokio` `features=["full"]` (includes `test-util`). ✓
+- `Result<T>` alias (1 generic param) in egress — Task 2 tests use `Result<i32>`, NOT `Result<i32, EgressError>` (the original Task 2's `Result<i32, EgressError>` was a compile error; corrected here). ✓
+- `1u64.checked_shl(attempt - 1)` — `attempt: u32`, `attempt-1: u32`, `u64::checked_shl(u32)` — compiles. ✓
+- `max_retries.min(10)` clamp — Task 2 Step 4 clamps to 10, matching the spec's Fix 2b ceiling. ✓
+- 429 classification UNCHANGED — `RateLimitExceeded` stays non-retryable (propagates to routing); `ProviderError{429}` stays retryable. ✓
+
+**4. Regression risk:**
+- This plan does NOT touch the 429 path, so `limits_alternative_strategy` (routing-layer 429 failover) stays green (Step 6 verifies). ✓
+- The backoff expression change is value-identical for realistic max_retries (3-10), so existing retry tests are unaffected. ✓
 
 No issues found. Plan is complete.

--- a/docs/superpowers/specs/2026-07-02-retry-rate-limit-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-02-retry-rate-limit-consistency-design.md
@@ -1,0 +1,273 @@
+# Retry / Rate-Limit Consistency — Design
+
+**Date:** 2026-07-02
+**Scope:** Batch C of the adversarial code-review findings — retry/rate-limit consistency (issues #8, #11, #14). Fixes two opposite 429-handling bugs (Anthropic 429 retried blindly ignoring `retry-after`; OpenAI 429 never retried at all) and a backoff overflow panic for large `max_retries`.
+**Status:** Findings independently validated by a Codex GPT-5.5 (xhigh) pass that read the actual source (all three CONFIRMED).
+
+## Context
+
+LunaRoute's egress layer retries transient upstream failures in `with_retry` (`crates/lunaroute-egress/src/client.rs:127`). The two providers disagree on how to surface 429:
+
+- **OpenAI** (`handle_openai_response` at `openai.rs:1829`, `handle_openai_passthrough_response` at `openai.rs:596`): reads the `retry-after` header and returns `EgressError::RateLimitExceeded { retry_after_secs }` for 429.
+- **Anthropic** (`handle_anthropic_response` at `anthropic.rs:1022`): returns `EgressError::ProviderError { status_code, message }` for ALL non-success statuses (including 429), never reading `retry-after`.
+
+`with_retry` then classifies errors: `ProviderError` with `status_code` 429 is retryable (retried with fixed exponential backoff, ignoring any retry-after), but `RateLimitExceeded` is NOT in the retryable list (`_ => false`), so OpenAI 429 is never retried. Net result: **Anthropic 429 is retried blindly (ignoring `retry-after`); OpenAI 429 is not retried at all.** Both are wrong, in opposite directions.
+
+Additionally, the backoff expression `2u64.pow(attempt - 1) * 100` (client.rs:152) panics in debug (wraps in release) when `max_retries >= 65` — a misconfiguration that no config validation clamps.
+
+## Goals
+
+1. **Unified 429 policy:** 429 from either provider → the response handler returns `EgressError::RateLimitExceeded { retry_after_secs }` (reading the `retry-after` header). Both providers behave identically.
+2. **`with_retry` honors `retry-after`:** retry `RateLimitExceeded` sleeping for `retry_after_secs` (capped at 60s per retry); fall back to (fixed, non-overflowing) exponential backoff when `retry_after` is absent; bail early (return the error) when `retry_after` exceeds the cap, so a daily-quota 429 (86400s) fails fast to the client instead of blocking for minutes.
+3. **Fix the backoff overflow:** saturating exponentiation + a config clamp on `max_retries` (ceiling 10) so the panic is unreachable by construction.
+
+## Non-goals
+
+- Changes to the non-429 error paths (`ProviderError` 500/502/503/504, `HttpError`, `Timeout`) — their retry behavior is unchanged.
+- A cumulative sleep budget across retries — `max_retries` (clamped to ≤10) already bounds the count; 10 × 60s = 600s worst case is acceptable for a proxy willing to retry. No separate cumulative cap.
+- Changes to `parse_retry_after` (already solid: handles numeric + HTTP-date, caps at 48h). The Anthropic path just needs to *call* it.
+- The other review batches (secrets-at-rest, async hygiene). Each is its own spec.
+
+---
+
+## Fix 1 (MEDIUM × 2): Unified 429 policy + retry-after-honoring retry (fixes #8 + #11)
+
+### Change 1a — Anthropic returns `RateLimitExceeded` for 429 (fixes #8)
+
+**File:** `crates/lunaroute-egress/src/anthropic.rs`, `handle_anthropic_response` (~line 1022).
+
+Mirror the OpenAI handler's pattern: capture `retry-after` before consuming the body, return `RateLimitExceeded` for 429, `ProviderError` for other non-success.
+
+```rust
+async fn handle_anthropic_response(self) -> Result<AnthropicResponse> {
+    let status = self.status();
+
+    // Capture retry-after header before consuming response
+    let retry_after_secs = self
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(crate::parse_retry_after);
+
+    if !status.is_success() {
+        let status_code = status.as_u16();
+        let body = self
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unable to read error body".to_string());
+
+        return Err(if status_code == 429 {
+            debug!(
+                retry_after_secs = ?retry_after_secs,
+                "Anthropic rate limit exceeded"
+            );
+            EgressError::RateLimitExceeded { retry_after_secs }
+        } else {
+            EgressError::ProviderError {
+                status_code,
+                message: body,
+            }
+        });
+    }
+
+    let response = self.json::<AnthropicResponse>().await.map_err(|e| {
+        EgressError::ParseError(format!("Failed to parse Anthropic response: {}", e))
+    })?;
+
+    Ok(response)
+}
+```
+
+`parse_retry_after` is `crate::parse_retry_after` (already public, already used by the OpenAI path). `debug!` and `EgressError` are already in scope. This makes both providers return the same error variant for 429.
+
+### Change 1b — `with_retry` retries `RateLimitExceeded` honoring retry-after (fixes #11)
+
+**File:** `crates/lunaroute-egress/src/client.rs`, `with_retry` (~line 127).
+
+**New module-scope constant:**
+```rust
+/// Maximum sleep (seconds) for a single rate-limit retry. Longer retry-after
+/// values (e.g. daily quotas ~86400s) bail to the client immediately instead
+/// of blocking the request for minutes. 60s covers real-world per-minute
+/// rate limits from both OpenAI and Anthropic.
+const RATE_LIMIT_SLEEP_CAP_SECS: u64 = 60;
+```
+
+**Restructure the loop** so the sleep is driven by the *error* (which carries `retry_after_secs`), not computed before the operation. Today the loop sleeps at the top (before the operation, based only on `attempt`); the retry-after comes from the error at the bottom. The restructure moves the sleep to *after* the failed operation:
+
+```rust
+pub async fn with_retry<F, Fut, T>(max_retries: u32, operation: F) -> Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut last_error = None;
+
+    for attempt in 0..=max_retries {
+        // Sleep before retries (skipped on the first attempt). The sleep
+        // duration is driven by the PREVIOUS attempt's error so we can honor
+        // retry-after for rate limits.
+        if attempt > 0 {
+            let backoff_ms = match &last_error {
+                Some(EgressError::RateLimitExceeded {
+                    retry_after_secs: Some(ras),
+                }) => {
+                    if *ras > RATE_LIMIT_SLEEP_CAP_SECS {
+                        // retry-after too long: bail to the client immediately
+                        debug!(
+                            retry_after_secs = ras,
+                            cap = RATE_LIMIT_SLEEP_CAP_SECS,
+                            "rate-limit retry-after exceeds cap; returning error to client"
+                        );
+                        return Err(last_error.unwrap());
+                    }
+                    // Honor the provider's retry-after (seconds -> ms)
+                    ras.saturating_mul(1000)
+                }
+                _ => {
+                    // Exponential backoff for non-rate-limit errors, or
+                    // rate-limit with no retry-after header.
+                    // Saturating: prevents overflow for large max_retries.
+                    (1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX))
+                        .saturating_mul(100)
+                }
+            };
+            debug!(
+                "Retrying request after {}ms (attempt {}/{})",
+                backoff_ms, attempt, max_retries
+            );
+            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+        }
+
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                // Check if error is retryable
+                let should_retry = match &e {
+                    EgressError::HttpError(req_err) => {
+                        req_err.is_connect() || req_err.is_timeout() || req_err.is_request()
+                    }
+                    EgressError::ProviderError { status_code, .. } => {
+                        // Retry on 429 (rate limit), 500, 502, 503, 504.
+                        // 429 here is a defensive fallback: providers SHOULD
+                        // return RateLimitExceeded for 429 (which has its own
+                        // arm below), but if a path returns ProviderError for
+                        // 429 it still retries with exponential backoff.
+                        matches!(status_code, 429 | 500 | 502 | 503 | 504)
+                    }
+                    EgressError::RateLimitExceeded { .. } => true,
+                    EgressError::Timeout(_) => true,
+                    _ => false,
+                };
+
+                if should_retry && attempt < max_retries {
+                    warn!(
+                        "Request failed (attempt {}/{}): {:?}",
+                        attempt + 1,
+                        max_retries,
+                        e
+                    );
+                    last_error = Some(e);
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        EgressError::ConfigError("Retry loop exited unexpectedly".to_string())
+    }))
+}
+```
+
+**Key behaviors of the restructure:**
+- The sleep now happens at the *top* of each retry iteration (still before the operation), but its duration is computed from `last_error` (the previous attempt's error) — so retry-after is honored. `last_error` is already set at the bottom of the loop today; this just reads it at the top of the next iteration.
+- `RateLimitExceeded { retry_after_secs: Some(ras) }` with `ras > 60` → bail immediately (return the error), don't sleep.
+- `RateLimitExceeded { retry_after_secs: Some(ras) }` with `ras <= 60` → sleep `ras * 1000` ms.
+- `RateLimitExceeded { retry_after_secs: None }` → exponential backoff (no header to honor).
+- `ProviderError` 429 (defensive fallback) → exponential backoff (no retry-after available on this variant).
+- Other retryable errors → exponential backoff.
+
+### Behavior contract
+
+| Scenario | Today | After |
+|---|---|---|
+| Anthropic 429, `retry-after: 2s` | retried blindly at 100/200/400ms (ignores header) → likely more 429s | retried at 2s, 2s, 2s (honors header) up to `max_retries` |
+| OpenAI 429, `retry-after: 2s` | NOT retried → immediate client failure | retried at 2s up to `max_retries` |
+| Either 429, `retry-after: 50s` | Anthropic: blind retry; OpenAI: bail | retried at 50s (under 60s cap) |
+| Either 429, `retry-after: 86400s` (daily quota) | Anthropic: blind retry; OpenAI: bail | bail immediately, return `RateLimitExceeded { retry_after_secs: Some(86400) }` to client |
+| Either 429, no `retry-after` header | Anthropic: blind exponential; OpenAI: bail | exponential backoff (100/200/400ms) for both |
+| Non-429 retryable (500/502/503/504, timeout, network) | exponential backoff | unchanged (exponential backoff) |
+
+---
+
+## Fix 2 (LOW): Backoff overflow + config clamp (fixes #14)
+
+**File:** `crates/lunaroute-egress/src/client.rs` (backoff expression, now inside the restructured `with_retry`) + `crates/lunaroute-server/src/config.rs` (`max_retries` clamp).
+
+### Change 2a — Saturating backoff expression
+
+The exponential backoff (used for non-rate-limit errors, and rate-limit with no header) is now (per Fix 1b's code):
+
+```rust
+(1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100)
+```
+
+`checked_shl(n)` returns `Some(1 << n)` for `n < 64`, `None` for `n >= 64` → `unwrap_or(u64::MAX)` caps the base; `saturating_mul(100)` caps the product. For realistic `max_retries` (3-10) the value is identical to today (`100, 200, 400...`). For pathological `max_retries >= 65` it saturates to `u64::MAX` ms instead of panicking/wrapping.
+
+### Change 2b — Clamp `max_retries` at config parse (ceiling 10)
+
+**File:** `crates/lunaroute-server/src/config.rs`, in `to_http_client_config` (~line 225, where `max_retries: self.max_retries.unwrap_or(defaults.max_retries)` is set):
+
+```rust
+max_retries: self.max_retries.unwrap_or(defaults.max_retries).min(10),
+```
+
+Add a warn log when clamping (compare the unwrapped value to 10):
+
+```rust
+let max_retries = self.max_retries.unwrap_or(defaults.max_retries);
+if max_retries > 10 {
+    warn!(
+        requested = max_retries,
+        clamped = 10,
+        "max_retries exceeds safe ceiling; clamping to 10"
+    );
+}
+// then use max_retries.min(10) in the struct literal
+```
+
+Ceiling 10: 10 retries × ~60s worst-case rate-limit sleep = 600s, already beyond sane for a proxy. The clamp makes the overflow unreachable by construction (10 << 64 is far from overflow); the saturating expression (2a) is belt-and-suspenders.
+
+### Behavior contract
+
+- `max_retries: 3` (default) → backoff `100, 200, 400` ms — unchanged.
+- `max_retries: 10` (the ceiling) → backoff `100, 200, 400, 800, ...` up to `51200` ms — no overflow.
+- `max_retries: 100` (would panic today) → clamped to 10 with a warn log; no panic.
+- Even without the clamp (e.g. a future caller bypassing config), the saturating expression won't panic.
+
+---
+
+## Validation status
+
+All three findings independently CONFIRMED by a Codex GPT-5.5 (xhigh) validator that read the actual source:
+
+| # | Issue | Validator verdict | Evidence (file:line read by validator) |
+|---|---|---|---|
+| 8 | `with_retry` retries Anthropic 429 ignoring `retry-after` | CONFIRMED | client.rs:138-157 (retries `ProviderError` 429 with fixed backoff); anthropic.rs:1004-1014 (429→`ProviderError`, no retry-after reading) |
+| 11 | OpenAI passthrough 429 `RateLimitExceeded` never retried; `ProviderError` 429 is | CONFIRMED | client.rs:155-160 (`_ => false` for `RateLimitExceeded`); openai.rs:616-621 (returns `RateLimitExceeded`) |
+| 14 | `2u64.pow(attempt-1)` backoff overflow panic for `max_retries ≥ 65` | CONFIRMED | client.rs:138-139 (the `pow`); config.rs:174-194 (`max_retries: Option<u32>` unclamped) |
+
+## Rollout
+
+The fixes are in one PR but ship as a coherent unit (they share `with_retry` and the response handlers, and #8 + #11 are interdependent — fixing #8 without #11 would make Anthropic 429 unretried, worse than today). Recommended order within the PR (dependency, soft):
+
+1. **Fix 1a** (Anthropic → `RateLimitExceeded`) + **Fix 1b** (`with_retry` honors retry-after) together — they must land as a unit to avoid the transient-worse intermediate state.
+2. **Fix 2** (saturating backoff + config clamp) — folds into the `with_retry` restructure naturally (the new backoff expression is part of Fix 1b's code).
+
+No database migrations. No new config fields (`max_retries` already exists; we only clamp it). No public API changes (`EgressError::RateLimitExceeded` already exists; `with_retry`'s signature is unchanged).
+
+## Open questions
+
+None at design time. The two behavioral decisions (60s per-retry cap; no cumulative cap; clamp ceiling 10) were made during brainstorming.

--- a/docs/superpowers/specs/2026-07-02-retry-rate-limit-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-02-retry-rate-limit-consistency-design.md
@@ -1,273 +1,136 @@
-# Retry / Rate-Limit Consistency — Design
+# Retry / Rate-Limit Consistency — Design (revised)
 
-**Date:** 2026-07-02
-**Scope:** Batch C of the adversarial code-review findings — retry/rate-limit consistency (issues #8, #11, #14). Fixes two opposite 429-handling bugs (Anthropic 429 retried blindly ignoring `retry-after`; OpenAI 429 never retried at all) and a backoff overflow panic for large `max_retries`.
-**Status:** Findings independently validated by a Codex GPT-5.5 (xhigh) pass that read the actual source (all three CONFIRMED).
+**Date:** 2026-07-02 (revised after SDD Task 2 surfaced an architecture conflict)
+**Scope:** Batch C of the adversarial code-review findings — retry/rate-limit consistency (issues #8, #14; #11 re-evaluated).
+**Status:** Findings independently validated by a Codex GPT-5.5 (xhigh) pass. The original design was revised after Task 2's implementation broke 6 routing integration tests, revealing that the routing layer — not the egress `with_retry` — is the intended owner of 429 retry/failover.
 
-## Context
+## Context (corrected)
 
-LunaRoute's egress layer retries transient upstream failures in `with_retry` (`crates/lunaroute-egress/src/client.rs:127`). The two providers disagree on how to surface 429:
+LunaRoute has TWO layers that touch 429:
 
-- **OpenAI** (`handle_openai_response` at `openai.rs:1829`, `handle_openai_passthrough_response` at `openai.rs:596`): reads the `retry-after` header and returns `EgressError::RateLimitExceeded { retry_after_secs }` for 429.
-- **Anthropic** (`handle_anthropic_response` at `anthropic.rs:1022`): returns `EgressError::ProviderError { status_code, message }` for ALL non-success statuses (including 429), never reading `retry-after`.
+- **Egress `with_retry`** (`crates/lunaroute-egress/src/client.rs:127`): retries transient upstream errors (network, timeout, 500/502/503/504) on the SAME provider. It classifies errors: `ProviderError{429}` is retryable (blind exponential backoff, ignores `retry-after`); `RateLimitExceeded{...}` is NOT retryable (`_ => false`) — it propagates up.
+- **Routing layer** (`crates/lunaroute-routing/src/provider_router.rs:255`, `strategy.rs`): when a request fails with `Error::RateLimitExceeded { retry_after_secs }`, the router records the provider as rate-limited (`record_rate_limit(retry_after_secs, ...)`), marks it rate-limited until `retry-after` expires, and **switches to an alternative provider** (`limits_alternative_strategy`). This is a complete, retry-after-aware 429 failover system at the routing layer.
 
-`with_retry` then classifies errors: `ProviderError` with `status_code` 429 is retryable (retried with fixed exponential backoff, ignoring any retry-after), but `RateLimitExceeded` is NOT in the retryable list (`_ => false`), so OpenAI 429 is never retried. Net result: **Anthropic 429 is retried blindly (ignoring `retry-after`); OpenAI 429 is not retried at all.** Both are wrong, in opposite directions.
+The two providers disagreed on how to surface 429:
+- **OpenAI** (`handle_openai_response`): reads `retry-after`, returns `RateLimitExceeded { retry_after_secs }` → propagates to routing → failover. ✅ correct
+- **Anthropic** (`handle_anthropic_response`): returned `ProviderError { status_code: 429, ... }` for ALL non-success (including 429), never reading `retry-after` → egress `with_retry` retries it blindly (3× exponential backoff, ignoring retry-after) on the SAME provider → the routing layer never sees `RateLimitExceeded`, so **no failover**. ❌ the actual bug
 
-Additionally, the backoff expression `2u64.pow(attempt - 1) * 100` (client.rs:152) panics in debug (wraps in release) when `max_retries >= 65` — a misconfiguration that no config validation clamps.
+## What the original review found vs what's really true
 
-## Goals
+| # | Original finding | Re-evaluation |
+|---|---|---|
+| #8 | "Anthropic 429 retried blindly, ignores retry-after" | **CONFIRMED, real bug.** Anthropic returns `ProviderError` for 429, so egress retries it blindly (no failover, ignores retry-after). Fix: Anthropic returns `RateLimitExceeded` (Task 1). |
+| #11 | "OpenAI 429 (`RateLimitExceeded`) never retried" | **MISDIAGNOSED.** It is *correct* that egress does NOT retry `RateLimitExceeded` — that error is meant to propagate to the routing layer, which does retry-after-aware failover (a better behavior than same-provider retry). The asymmetry was NOT "OpenAI unretried vs Anthropic retried" — it was "OpenAI correctly propagates to routing; Anthropic wrongly retries at egress." Task 1 (Anthropic → `RateLimitExceeded`) fixes the asymmetry by making Anthropic also propagate to routing. **No `with_retry` change needed for 429.** |
+| #14 | "backoff `2u64.pow(attempt-1)` overflow panic for max_retries ≥ 65" | **CONFIRMED, real bug.** The overflow is in the non-429 retry path (500/502/503/504, network, timeout). Fix: saturating expression + config clamp. |
 
-1. **Unified 429 policy:** 429 from either provider → the response handler returns `EgressError::RateLimitExceeded { retry_after_secs }` (reading the `retry-after` header). Both providers behave identically.
-2. **`with_retry` honors `retry-after`:** retry `RateLimitExceeded` sleeping for `retry_after_secs` (capped at 60s per retry); fall back to (fixed, non-overflowing) exponential backoff when `retry_after` is absent; bail early (return the error) when `retry_after` exceeds the cap, so a daily-quota 429 (86400s) fails fast to the client instead of blocking for minutes.
-3. **Fix the backoff overflow:** saturating exponentiation + a config clamp on `max_retries` (ceiling 10) so the panic is unreachable by construction.
+The original design's "make `with_retry` retry `RateLimitExceeded` honoring retry-after" was **wrong**: it would make the egress layer retry the same rate-limited provider (sleeping up to 60s × 3) before the routing layer could failover to an alternative — defeating the routing layer's failover design, breaking the `limits_alternative_strategy` tests (which assert `.expect(1)` on the primary — exactly 1 request then switch), and making tests take 360s (CI timeout).
 
-## Non-goals
+## Goals (revised)
 
-- Changes to the non-429 error paths (`ProviderError` 500/502/503/504, `HttpError`, `Timeout`) — their retry behavior is unchanged.
-- A cumulative sleep budget across retries — `max_retries` (clamped to ≤10) already bounds the count; 10 × 60s = 600s worst case is acceptable for a proxy willing to retry. No separate cumulative cap.
-- Changes to `parse_retry_after` (already solid: handles numeric + HTTP-date, caps at 48h). The Anthropic path just needs to *call* it.
+1. **Unified 429 propagation:** 429 from either provider → the egress response handler returns `EgressError::RateLimitExceeded { retry_after_secs }` (reading `retry-after`), which `with_retry` does NOT retry — it propagates to the routing layer for retry-after-aware failover. (Task 1 — DONE, commit `d32d3fe`.)
+2. **Fix the backoff overflow (#14):** saturating exponentiation + config clamp on `max_retries` (ceiling 10) so the panic is unreachable. The backoff is used for the non-429 retryable errors (500/502/503/504, network, timeout) — those still retry at egress (correct: same-provider retry for transient errors). This does NOT touch the 429 path.
+
+## Non-goals (revised)
+
+- **Do NOT make `with_retry` retry `RateLimitExceeded`.** `RateLimitExceeded` must propagate to the routing layer (which does failover). The original design's retry-after-honoring retry at egress is dropped — it conflicts with the routing layer's failover.
+- No changes to the routing layer's rate-limit/failover (`provider_router.rs`, `strategy.rs`) — it's already correct and complete.
+- No changes to `parse_retry_after` (already solid, used by both handler paths + routing).
 - The other review batches (secrets-at-rest, async hygiene). Each is its own spec.
 
 ---
 
-## Fix 1 (MEDIUM × 2): Unified 429 policy + retry-after-honoring retry (fixes #8 + #11)
+## Fix 1 (MEDIUM, fixes #8): Anthropic returns `RateLimitExceeded` for 429 — DONE
 
-### Change 1a — Anthropic returns `RateLimitExceeded` for 429 (fixes #8)
+**Status:** Implemented and reviewed (commit `d32d3fe`, Task 1 of this batch). `handle_anthropic_response` now reads `retry-after` and returns `RateLimitExceeded { retry_after_secs }` for 429 (mirroring OpenAI). Both providers now propagate 429 to the routing layer uniformly.
 
-**File:** `crates/lunaroute-egress/src/anthropic.rs`, `handle_anthropic_response` (~line 1022).
+**Net effect:** Anthropic 429 now triggers routing-layer failover (to an alternative provider) instead of being blind-retried at egress. This is the real fix for #8 — and it simultaneously resolves the #11 asymmetry (both providers now behave identically: `RateLimitExceeded` propagates to routing).
 
-Mirror the OpenAI handler's pattern: capture `retry-after` before consuming the body, return `RateLimitExceeded` for 429, `ProviderError` for other non-success.
+## Fix 2 (LOW, fixes #14): Saturating backoff + config clamp
 
-```rust
-async fn handle_anthropic_response(self) -> Result<AnthropicResponse> {
-    let status = self.status();
+**Location:** `crates/lunaroute-egress/src/client.rs` (backoff expression at line 152) + `crates/lunaroute-server/src/config.rs` (`to_http_client_config` ~line 225).
 
-    // Capture retry-after header before consuming response
-    let retry_after_secs = self
-        .headers()
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(crate::parse_retry_after);
-
-    if !status.is_success() {
-        let status_code = status.as_u16();
-        let body = self
-            .text()
-            .await
-            .unwrap_or_else(|_| "Unable to read error body".to_string());
-
-        return Err(if status_code == 429 {
-            debug!(
-                retry_after_secs = ?retry_after_secs,
-                "Anthropic rate limit exceeded"
-            );
-            EgressError::RateLimitExceeded { retry_after_secs }
-        } else {
-            EgressError::ProviderError {
-                status_code,
-                message: body,
-            }
-        });
-    }
-
-    let response = self.json::<AnthropicResponse>().await.map_err(|e| {
-        EgressError::ParseError(format!("Failed to parse Anthropic response: {}", e))
-    })?;
-
-    Ok(response)
-}
-```
-
-`parse_retry_after` is `crate::parse_retry_after` (already public, already used by the OpenAI path). `debug!` and `EgressError` are already in scope. This makes both providers return the same error variant for 429.
-
-### Change 1b — `with_retry` retries `RateLimitExceeded` honoring retry-after (fixes #11)
-
-**File:** `crates/lunaroute-egress/src/client.rs`, `with_retry` (~line 127).
-
-**New module-scope constant:**
-```rust
-/// Maximum sleep (seconds) for a single rate-limit retry. Longer retry-after
-/// values (e.g. daily quotas ~86400s) bail to the client immediately instead
-/// of blocking the request for minutes. 60s covers real-world per-minute
-/// rate limits from both OpenAI and Anthropic.
-const RATE_LIMIT_SLEEP_CAP_SECS: u64 = 60;
-```
-
-**Restructure the loop** so the sleep is driven by the *error* (which carries `retry_after_secs`), not computed before the operation. Today the loop sleeps at the top (before the operation, based only on `attempt`); the retry-after comes from the error at the bottom. The restructure moves the sleep to *after* the failed operation:
-
-```rust
-pub async fn with_retry<F, Fut, T>(max_retries: u32, operation: F) -> Result<T>
-where
-    F: Fn() -> Fut,
-    Fut: std::future::Future<Output = Result<T>>,
-{
-    let mut last_error = None;
-
-    for attempt in 0..=max_retries {
-        // Sleep before retries (skipped on the first attempt). The sleep
-        // duration is driven by the PREVIOUS attempt's error so we can honor
-        // retry-after for rate limits.
-        if attempt > 0 {
-            let backoff_ms = match &last_error {
-                Some(EgressError::RateLimitExceeded {
-                    retry_after_secs: Some(ras),
-                }) => {
-                    if *ras > RATE_LIMIT_SLEEP_CAP_SECS {
-                        // retry-after too long: bail to the client immediately
-                        debug!(
-                            retry_after_secs = ras,
-                            cap = RATE_LIMIT_SLEEP_CAP_SECS,
-                            "rate-limit retry-after exceeds cap; returning error to client"
-                        );
-                        return Err(last_error.unwrap());
-                    }
-                    // Honor the provider's retry-after (seconds -> ms)
-                    ras.saturating_mul(1000)
-                }
-                _ => {
-                    // Exponential backoff for non-rate-limit errors, or
-                    // rate-limit with no retry-after header.
-                    // Saturating: prevents overflow for large max_retries.
-                    (1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX))
-                        .saturating_mul(100)
-                }
-            };
-            debug!(
-                "Retrying request after {}ms (attempt {}/{})",
-                backoff_ms, attempt, max_retries
-            );
-            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-        }
-
-        match operation().await {
-            Ok(result) => return Ok(result),
-            Err(e) => {
-                // Check if error is retryable
-                let should_retry = match &e {
-                    EgressError::HttpError(req_err) => {
-                        req_err.is_connect() || req_err.is_timeout() || req_err.is_request()
-                    }
-                    EgressError::ProviderError { status_code, .. } => {
-                        // Retry on 429 (rate limit), 500, 502, 503, 504.
-                        // 429 here is a defensive fallback: providers SHOULD
-                        // return RateLimitExceeded for 429 (which has its own
-                        // arm below), but if a path returns ProviderError for
-                        // 429 it still retries with exponential backoff.
-                        matches!(status_code, 429 | 500 | 502 | 503 | 504)
-                    }
-                    EgressError::RateLimitExceeded { .. } => true,
-                    EgressError::Timeout(_) => true,
-                    _ => false,
-                };
-
-                if should_retry && attempt < max_retries {
-                    warn!(
-                        "Request failed (attempt {}/{}): {:?}",
-                        attempt + 1,
-                        max_retries,
-                        e
-                    );
-                    last_error = Some(e);
-                } else {
-                    return Err(e);
-                }
-            }
-        }
-    }
-
-    Err(last_error.unwrap_or_else(|| {
-        EgressError::ConfigError("Retry loop exited unexpectedly".to_string())
-    }))
-}
-```
-
-**Key behaviors of the restructure:**
-- The sleep now happens at the *top* of each retry iteration (still before the operation), but its duration is computed from `last_error` (the previous attempt's error) — so retry-after is honored. `last_error` is already set at the bottom of the loop today; this just reads it at the top of the next iteration.
-- `RateLimitExceeded { retry_after_secs: Some(ras) }` with `ras > 60` → bail immediately (return the error), don't sleep.
-- `RateLimitExceeded { retry_after_secs: Some(ras) }` with `ras <= 60` → sleep `ras * 1000` ms.
-- `RateLimitExceeded { retry_after_secs: None }` → exponential backoff (no header to honor).
-- `ProviderError` 429 (defensive fallback) → exponential backoff (no retry-after available on this variant).
-- Other retryable errors → exponential backoff.
-
-### Behavior contract
-
-| Scenario | Today | After |
-|---|---|---|
-| Anthropic 429, `retry-after: 2s` | retried blindly at 100/200/400ms (ignores header) → likely more 429s | retried at 2s, 2s, 2s (honors header) up to `max_retries` |
-| OpenAI 429, `retry-after: 2s` | NOT retried → immediate client failure | retried at 2s up to `max_retries` |
-| Either 429, `retry-after: 50s` | Anthropic: blind retry; OpenAI: bail | retried at 50s (under 60s cap) |
-| Either 429, `retry-after: 86400s` (daily quota) | Anthropic: blind retry; OpenAI: bail | bail immediately, return `RateLimitExceeded { retry_after_secs: Some(86400) }` to client |
-| Either 429, no `retry-after` header | Anthropic: blind exponential; OpenAI: bail | exponential backoff (100/200/400ms) for both |
-| Non-429 retryable (500/502/503/504, timeout, network) | exponential backoff | unchanged (exponential backoff) |
-
----
-
-## Fix 2 (LOW): Backoff overflow + config clamp (fixes #14)
-
-**File:** `crates/lunaroute-egress/src/client.rs` (backoff expression, now inside the restructured `with_retry`) + `crates/lunaroute-server/src/config.rs` (`max_retries` clamp).
+**Root cause:** `let backoff_ms = 2u64.pow(attempt - 1) * 100;`. For `max_retries >= 65`, `attempt - 1` reaches 64 and `2u64.pow(64)` overflows — panic in debug, wraparound in release. No config validation clamps `max_retries`. This affects the non-429 retryable errors (500/502/503/504, network, timeout) — those still retry at egress (correct behavior, unchanged).
 
 ### Change 2a — Saturating backoff expression
 
-The exponential backoff (used for non-rate-limit errors, and rate-limit with no header) is now (per Fix 1b's code):
+In `with_retry` (client.rs:152), replace:
 
 ```rust
-(1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100)
+let backoff_ms = 2u64.pow(attempt - 1) * 100; // Exponential backoff: 100ms, 200ms, 400ms
 ```
 
-`checked_shl(n)` returns `Some(1 << n)` for `n < 64`, `None` for `n >= 64` → `unwrap_or(u64::MAX)` caps the base; `saturating_mul(100)` caps the product. For realistic `max_retries` (3-10) the value is identical to today (`100, 200, 400...`). For pathological `max_retries >= 65` it saturates to `u64::MAX` ms instead of panicking/wrapping.
+with:
+
+```rust
+// Exponential backoff: 100ms, 200ms, 400ms ... saturating to avoid overflow
+// for large max_retries (2u64.pow(64) would panic; checked_shl + saturating_mul
+// caps instead). For realistic max_retries (3-10) values are identical to today.
+let backoff_ms = (1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100);
+```
+
+`checked_shl(n)` returns `Some(1 << n)` for `n < 64`, `None` for `n >= 64` → `unwrap_or(u64::MAX)` caps the base; `saturating_mul(100)` caps the product. For realistic `max_retries` (3-10) the value is identical to today (`100, 200, 400...`). For pathological `max_retries >= 65` it saturates instead of panicking.
+
+**No loop restructure.** The `with_retry` loop keeps its current shape (sleep at the top, computed from `attempt`). Only the backoff expression changes. The 429 classification (`ProviderError{429}` retryable, `RateLimitExceeded` not retryable) is UNCHANGED — that's the correct behavior (propagate to routing).
 
 ### Change 2b — Clamp `max_retries` at config parse (ceiling 10)
 
-**File:** `crates/lunaroute-server/src/config.rs`, in `to_http_client_config` (~line 225, where `max_retries: self.max_retries.unwrap_or(defaults.max_retries)` is set):
+**File:** `crates/lunaroute-server/src/config.rs`, `to_http_client_config` (~line 225). Replace:
 
 ```rust
-max_retries: self.max_retries.unwrap_or(defaults.max_retries).min(10),
+max_retries: self.max_retries.unwrap_or(defaults.max_retries),
 ```
 
-Add a warn log when clamping (compare the unwrapped value to 10):
+with:
 
 ```rust
-let max_retries = self.max_retries.unwrap_or(defaults.max_retries);
-if max_retries > 10 {
-    warn!(
-        requested = max_retries,
-        clamped = 10,
-        "max_retries exceeds safe ceiling; clamping to 10"
-    );
-}
-// then use max_retries.min(10) in the struct literal
+max_retries: {
+    let requested = self.max_retries.unwrap_or(defaults.max_retries);
+    if requested > 10 {
+        warn!(
+            requested = requested,
+            clamped = 10,
+            "max_retries exceeds safe ceiling; clamping to 10"
+        );
+        10
+    } else {
+        requested
+    }
+},
 ```
 
-Ceiling 10: 10 retries × ~60s worst-case rate-limit sleep = 600s, already beyond sane for a proxy. The clamp makes the overflow unreachable by construction (10 << 64 is far from overflow); the saturating expression (2a) is belt-and-suspenders.
+(`warn` is already in scope via `tracing` in config.rs — verify with `rg -n 'use tracing' crates/lunaroute-server/src/config.rs`; add `warn` to the existing `use tracing::...` line if not present.)
+
+Ceiling 10: 10 retries × worst-case backoff (51200 ms at attempt 10) is already beyond sane for a proxy. The clamp makes the overflow unreachable by construction; the saturating expression (2a) is belt-and-suspenders.
 
 ### Behavior contract
 
 - `max_retries: 3` (default) → backoff `100, 200, 400` ms — unchanged.
-- `max_retries: 10` (the ceiling) → backoff `100, 200, 400, 800, ...` up to `51200` ms — no overflow.
+- `max_retries: 10` (ceiling) → backoff up to `51200` ms — no overflow.
 - `max_retries: 100` (would panic today) → clamped to 10 with a warn log; no panic.
-- Even without the clamp (e.g. a future caller bypassing config), the saturating expression won't panic.
+- 429 handling UNCHANGED: `ProviderError{429}` retried at egress (existing behavior, for any path that still returns it); `RateLimitExceeded{429}` propagates to routing (Task 1 made Anthropic use this path). The routing layer's failover is the 429 defense.
+
+### Tests
+
+- Unit (client.rs): `test_backoff_does_not_overflow_for_large_max_retries` — `with_retry(65, || async { Ok(42) })` succeeds on first attempt, no panic (documents the saturating expression is safe). Add a second test that forces the retry path with a non-429 retryable error (e.g. `ProviderError{500}`) and `max_retries: 65`, using `tokio::time::pause()` to avoid real sleeps, asserting it eventually returns the error without panicking. This proves the backoff expression doesn't overflow even on the retry path.
+- Unit (config.rs): `test_to_http_client_config_clamps_max_retries_to_10` (Some(100) → 10) and `test_to_http_client_config_preserves_max_retries_under_10` (Some(5) → 5). Mirror the existing `ProviderSettings` construction in `test_merge_http_client_env_all_variables`.
 
 ---
 
 ## Validation status
 
-All three findings independently CONFIRMED by a Codex GPT-5.5 (xhigh) validator that read the actual source:
-
-| # | Issue | Validator verdict | Evidence (file:line read by validator) |
+| # | Issue | Validator verdict | Re-evaluation |
 |---|---|---|---|
-| 8 | `with_retry` retries Anthropic 429 ignoring `retry-after` | CONFIRMED | client.rs:138-157 (retries `ProviderError` 429 with fixed backoff); anthropic.rs:1004-1014 (429→`ProviderError`, no retry-after reading) |
-| 11 | OpenAI passthrough 429 `RateLimitExceeded` never retried; `ProviderError` 429 is | CONFIRMED | client.rs:155-160 (`_ => false` for `RateLimitExceeded`); openai.rs:616-621 (returns `RateLimitExceeded`) |
-| 14 | `2u64.pow(attempt-1)` backoff overflow panic for `max_retries ≥ 65` | CONFIRMED | client.rs:138-139 (the `pow`); config.rs:174-194 (`max_retries: Option<u32>` unclamped) |
+| 8 | Anthropic 429 retried blindly, ignores retry-after | CONFIRMED | Real bug. Fixed by Task 1 (Anthropic → `RateLimitExceeded`, propagates to routing). DONE. |
+| 11 | OpenAI 429 (`RateLimitExceeded`) never retried | CONFIRMED | **MISDIAGNOSED.** Egress correctly does NOT retry `RateLimitExceeded` — it propagates to the routing layer's failover. The asymmetry was Anthropic returning `ProviderError` (retried blindly) — fixed by Task 1. No egress change needed. |
+| 14 | `2u64.pow(attempt-1)` overflow panic | CONFIRMED | Real bug. Fixed by saturating backoff + config clamp (Fix 2). |
 
-## Rollout
+## Rollout (revised)
 
-The fixes are in one PR but ship as a coherent unit (they share `with_retry` and the response handlers, and #8 + #11 are interdependent — fixing #8 without #11 would make Anthropic 429 unretried, worse than today). Recommended order within the PR (dependency, soft):
+- **Fix 1 (Task 1): DONE** — commit `d32d3fe`, reviewed and approved. Anthropic → `RateLimitExceeded`.
+- **Fix 2: pending** — saturating backoff + config clamp. Small, isolated to `client.rs` (one expression) + `config.rs` (one clamp). No loop restructure, no 429-classification change, no routing-layer change. No risk to the `limits_alternative_strategy` tests (they test 429 failover at routing; Fix 2 doesn't touch the 429 path).
 
-1. **Fix 1a** (Anthropic → `RateLimitExceeded`) + **Fix 1b** (`with_retry` honors retry-after) together — they must land as a unit to avoid the transient-worse intermediate state.
-2. **Fix 2** (saturating backoff + config clamp) — folds into the `with_retry` restructure naturally (the new backoff expression is part of Fix 1b's code).
-
-No database migrations. No new config fields (`max_retries` already exists; we only clamp it). No public API changes (`EgressError::RateLimitExceeded` already exists; `with_retry`'s signature is unchanged).
+No database migrations. No new config fields (`max_retries` already exists; we only clamp it). No public API changes (`with_retry` signature unchanged; `EgressError::RateLimitExceeded` reused as-is).
 
 ## Open questions
 
-None at design time. The two behavioral decisions (60s per-retry cap; no cumulative cap; clamp ceiling 10) were made during brainstorming.
+None at design time. The architecture correction (routing layer owns 429; egress propagates) was confirmed by reading `provider_router.rs:255` (`Error::RateLimitExceeded { retry_after_secs }` → `record_rate_limit` + switch to alternative) and the `limits_alternative_strategy` tests (which assert `.expect(1)` on the primary — exactly 1 request then failover).


### PR DESCRIPTION
## Summary

Fixes retry/rate-limit consistency defects from the adversarial code review (Batch C), independently validated by a second model (Codex GPT-5.5 xhigh) that read the actual source. Issue #8 (Anthropic 429 mishandled) and #14 (backoff overflow panic) are CONFIRMED and fixed. Issue #11 was re-evaluated as a **misdiagnosis** during implementation — see below.

Design spec: `docs/superpowers/specs/2026-07-02-retry-rate-limit-consistency-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-02-retry-rate-limit-consistency.md`

## Changes

### 1. #8 — Anthropic 429 returns `RateLimitExceeded` with `retry-after` (MEDIUM)
`handle_anthropic_response` returned `EgressError::ProviderError { status_code: 429, ... }` for ALL non-success statuses, never reading `retry-after`. This meant the egress `with_retry` retried it blindly (3× exponential backoff, ignoring `retry-after`) on the SAME provider, and the routing layer never saw `RateLimitExceeded` — so **no failover** to an alternative provider.

Now `handle_anthropic_response` mirrors the OpenAI handler: reads `retry-after` before consuming the body, returns `EgressError::RateLimitExceeded { retry_after_secs }` for 429. Both providers now propagate 429 uniformly to the routing layer, which performs retry-after-aware **failover to an alternative provider** (the `limits_alternative_strategy` feature).

### 2. #14 — Saturating backoff + `max_retries` clamp (LOW)
`with_retry`'s backoff expression `2u64.pow(attempt - 1) * 100` panicked in debug (wrapped in release) when `max_retries >= 65`, and no config validation clamped `max_retries`.

- Replaced with saturating `(1u64.checked_shl(attempt - 1).unwrap_or(u64::MAX)).saturating_mul(100)`. For realistic `max_retries` (3-10) values are identical to today (`100, 200, 400...`); for pathological `max_retries >= 65` it saturates instead of panicking.
- `max_retries` is now clamped to 10 in `to_http_client_config` with a `warn!` log. Belt-and-suspenders with the saturating expression; 10 retries is already beyond sane for a proxy.

## #11 was a misdiagnosis (no code change)

The original review said "OpenAI 429 (`RateLimitExceeded`) is never retried." During implementation, making `with_retry` retry `RateLimitExceeded` broke 6 `limits_alternative_strategy` integration tests (and made them take 360s). Investigation revealed the **routing layer already owns 429 retry/failover**: it matches `Error::RateLimitExceeded { retry_after_secs }`, records the provider as rate-limited, and switches to an alternative. The egress `with_retry` must NOT retry `RateLimitExceeded` — it must propagate to the routing layer. So it is CORRECT that egress doesn't retry `RateLimitExceeded`. The real asymmetry was Anthropic returning `ProviderError` (retried blindly at egress, no failover) — fixed by change #1 above (Anthropic now returns `RateLimitExceeded`, propagates to routing failover, matching OpenAI).

## Test plan
- Task 1: `test_handle_anthropic_response_429_returns_rate_limit_exceeded` — builds a 429 + `retry-after: 30` response, asserts `Err(RateLimitExceeded { Some(30) })`. Existing `test_anthropic_rate_limit_429_with_recording` integration test still passes (internal variant changed; client-visible 429 unchanged).
- Task 2: `test_backoff_does_not_overflow_for_large_max_retries_retry_path` — forces 66 attempts with `ProviderError{500}` and `max_retries=65` (paused time), asserts no panic. `test_to_http_client_config_clamps_max_retries_to_10` (Some(100)→10) and `_preserves_max_retries_under_10` (Some(5)→5).
- **Critical regression check:** `limits_alternative_strategy` (6 tests, routing-layer 429 failover) stays GREEN — this branch doesn't touch the 429 retry path at egress, so the routing failover is intact.

`cargo test --workspace --all-features` is green (0 failures). `cargo clippy --workspace --all-features -- -D warnings` and `cargo fmt --all -- --check` are clean. `limits_alternative_strategy` passes in ~1.25s (NOT 360s — the regression that triggered the revision is gone).

## Checklist
- [x] No new dependencies (`tokio`, `tracing`, `http`, `reqwest` already workspace deps)
- [x] No DB migrations / config-breaking changes (`max_retries` already exists; we only clamp it)
- [x] No public API changes (`with_retry` signature unchanged; `EgressError::RateLimitExceeded` reused as-is)
- [x] Routing layer untouched (it already owns 429 failover — the right layer)
- [x] Per-task + final whole-branch reviews clean (GPT-5.5 xhigh)
- [x] `limits_alternative_strategy` regression check green
